### PR TITLE
[#36] Verification and named functions can have generics

### DIFF
--- a/src/main/scala/definiti/core/Context.scala
+++ b/src/main/scala/definiti/core/Context.scala
@@ -68,8 +68,7 @@ private[core] case class ReferenceContext(
 
 private[core] case class ClassContext(
   outerContext: Context,
-  currentType: PureClassDefinition,
-  genericTypes: Seq[ClassReference]
+  currentType: PureClassDefinition
 ) extends Context {
   override def isTypeAvailable(typeName: String): Boolean = {
     currentType.genericTypes.contains(typeName) || outerContext.isTypeAvailable(typeName)
@@ -77,12 +76,14 @@ private[core] case class ClassContext(
 
   override def findType(typeName: String): Option[PureClassDefinition] = {
     if (currentType.genericTypes.contains(typeName)) {
-      val indexOfGeneric = currentType.genericTypes.indexOf(typeName)
-      if (indexOfGeneric < genericTypes.size) {
-        outerContext.findType(genericTypes(indexOfGeneric).classDefinition.name)
-      } else {
-        None
-      }
+      // There is neither covariance nor contravariance in the language, so the generic type is any type.
+      Some(PureNativeClassDefinition(
+        name = "A",
+        genericTypes = Seq.empty,
+        attributes = Seq.empty,
+        methods = Seq.empty,
+        comment = None
+      ))
     } else {
       outerContext.findType(typeName)
     }
@@ -120,12 +121,14 @@ private[core] case class MethodContext(
 
   override def findType(typeName: String): Option[PureClassDefinition] = {
     if (currentMethod.genericTypes.contains(typeName)) {
-      val indexOfGeneric = currentMethod.genericTypes.indexOf(typeName)
-      if (indexOfGeneric < genericTypes.size) {
-        outerContext.findType(genericTypes(indexOfGeneric).classDefinition.name)
-      } else {
-        None
-      }
+      // There is neither covariance nor contravariance in the language, so the generic type is any type.
+      Some(PureNativeClassDefinition(
+        name = "A",
+        genericTypes = Seq.empty,
+        attributes = Seq.empty,
+        methods = Seq.empty,
+        comment = None
+      ))
     } else {
       outerContext.findType(typeName)
     }
@@ -169,7 +172,18 @@ private[core] case class DefinedFunctionContext(
   }
 
   override def findType(typeName: String): Option[PureClassDefinition] = {
-    outerContext.findType(typeName)
+    if (currentFunction.genericTypes.contains(typeName)) {
+      // There is neither covariance nor contravariance in the language, so the generic type is any type.
+      Some(PureNativeClassDefinition(
+        name = "A",
+        genericTypes = Seq.empty,
+        attributes = Seq.empty,
+        methods = Seq.empty,
+        comment = None
+      ))
+    } else {
+      outerContext.findType(typeName)
+    }
   }
 
   override def isVerificationAvailable(verificationName: String): Boolean = {

--- a/src/main/scala/definiti/core/typing/ClassDefinitionTyping.scala
+++ b/src/main/scala/definiti/core/typing/ClassDefinitionTyping.scala
@@ -3,11 +3,9 @@ package definiti.core.typing
 import definiti.core.ast._
 import definiti.core.ast.pure._
 import definiti.core.ast.typed._
-import definiti.core.{Context, ValidValue, Validated}
+import definiti.core.{Context, DefinedFunctionContext, ValidValue, Validated}
 
 private[core] class ClassDefinitionTyping(context: Context) {
-  val functionTyping = new FunctionTyping(context)
-
   def addTypesIntoClassDefinition(classDefinition: PureClassDefinition): Validated[TypedClassDefinition] = {
     classDefinition match {
       case native: PureNativeClassDefinition => ValidValue(transformNativeClassDefinition(native))
@@ -43,7 +41,8 @@ private[core] class ClassDefinitionTyping(context: Context) {
   }
 
   def addTypesIntoTypeVerification(typeVerification: PureTypeVerification): Validated[TypeVerification] = {
-    val validatedFunction = functionTyping.addTypesIntoDefinedFunction(typeVerification.function)
+    val functionContext = DefinedFunctionContext(context, typeVerification.function)
+    val validatedFunction = new FunctionTyping(functionContext).addTypesIntoDefinedFunction(typeVerification.function)
     validatedFunction.map { function =>
       TypeVerification(
         message = typeVerification.message,

--- a/src/test/resources/samples/namedFunction/nonEmptyList.def
+++ b/src/test/resources/samples/namedFunction/nonEmptyList.def
@@ -1,0 +1,3 @@
+def nonEmptyList[A](list: List[A]): Boolean => {
+  list.nonEmpty()
+}

--- a/src/test/resources/samples/verification/NonEmptyList.def
+++ b/src/test/resources/samples/verification/NonEmptyList.def
@@ -1,0 +1,6 @@
+verification NonEmptyList {
+  "The list should not be empty"
+  [A](list: List[A]) => {
+    list.nonEmpty()
+  }
+}

--- a/src/test/scala/definiti/core/ValidationMatchers.scala
+++ b/src/test/scala/definiti/core/ValidationMatchers.scala
@@ -3,6 +3,7 @@ package definiti.core
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 trait ValidationMatchers {
+  import org.scalatest.Matchers._
 
   class ValidationMatcher(expected: Validation) extends Matcher[Validation] {
 
@@ -74,6 +75,10 @@ trait ValidationMatchers {
   def beValidation(expected: Validation) = new ValidationMatcher(expected)
 
   def beValidated[A](expected: Validated[A]) = new ValidatedMatcher[A](expected)
+
+  def valid[A] = a[ValidValue[A]]
+
+  def invalid = an[Invalid]
 }
 
 object ValidationMatchers extends ValidationMatchers

--- a/src/test/scala/definiti/core/end2end/EndToEndSpec.scala
+++ b/src/test/scala/definiti/core/end2end/EndToEndSpec.scala
@@ -3,7 +3,7 @@ package definiti.core.end2end
 import java.nio.file.Paths
 
 import definiti.core._
-import definiti.core.ast.Root
+import definiti.core.ast.{Location, Root}
 import definiti.core.mock.plugins.StringExtendedContext
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -32,5 +32,16 @@ trait EndToEndSpec extends FlatSpec with Matchers {
       apiSource = Paths.get(s"src/test/resources/core"),
       contexts = Seq(new StringExtendedContext())
     )
+  }
+}
+
+object EndToEndSpec {
+  case class LocationPath(path: String) {
+    def apply(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int): Location = {
+      Location(path, startLine, startColumn, endLine, endColumn)
+    }
+    def apply(line: Int, startColumn: Int, endColumn: Int): Location = {
+      Location(path, line, startColumn, line, endColumn)
+    }
   }
 }

--- a/src/test/scala/definiti/core/end2end/NamedFunctionSpec.scala
+++ b/src/test/scala/definiti/core/end2end/NamedFunctionSpec.scala
@@ -1,7 +1,7 @@
 package definiti.core.end2end
 
 import definiti.core.{ASTError, Invalid, ValidValue}
-import definiti.core.ValidationMatchers.beValidated
+import definiti.core.ValidationMatchers._
 import definiti.core.ast._
 
 class NamedFunctionSpec extends EndToEndSpec {
@@ -17,6 +17,11 @@ class NamedFunctionSpec extends EndToEndSpec {
     val expected = Invalid(invalidContainsGenerics)
     val output = processFile("namedFunction.invalid-contains-generics")
     output should beValidated[Root](expected)
+  }
+
+  "Project.generatePublicAST" should "accept generics in named functions" in {
+    val output = processFile("namedFunction.nonEmptyList")
+    output shouldBe valid[Root]
   }
 }
 

--- a/src/test/scala/definiti/core/end2end/VerificationFunctionSpec.scala
+++ b/src/test/scala/definiti/core/end2end/VerificationFunctionSpec.scala
@@ -15,7 +15,10 @@ class VerificationFunctionSpec extends EndToEndSpec {
 }
 
 object VerificationFunctionSpec {
+  import EndToEndSpec._
+
   val verificationFunctionSrc = "src/test/resources/samples/verificationFunction/verificationFunction.def"
+  val verificationFunctionLocation = LocationPath(verificationFunctionSrc)
   val validVerificationFunction = Root(Seq(
     Namespace(
       name = "verificationFunction",
@@ -102,12 +105,4 @@ object VerificationFunctionSpec {
       )
     )
   ))
-
-  def verificationFunctionLocation(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int) = {
-    Location(verificationFunctionSrc, startLine, startColumn, endLine, endColumn)
-  }
-
-  def verificationFunctionLocation(line: Int, startColumn: Int, endColumn: Int) = {
-    Location(verificationFunctionSrc, line, startColumn, line, endColumn)
-  }
 }

--- a/src/test/scala/definiti/core/end2end/VerificationSpec.scala
+++ b/src/test/scala/definiti/core/end2end/VerificationSpec.scala
@@ -1,0 +1,43 @@
+package definiti.core.end2end
+
+import definiti.core.ValidValue
+import definiti.core.ValidationMatchers.beValidated
+import definiti.core.ast._
+
+class VerificationSpec extends EndToEndSpec {
+  import VerificationSpec._
+
+  "Project.generatePublicAST" should "generate the AST for a valid verification with a generic" in {
+    val expected = ValidValue(validNonEmptyList)
+    val output = processFile("verification.NonEmptyList")
+    output should beValidated[Root](expected)
+  }
+}
+
+object VerificationSpec {
+  import EndToEndSpec._
+
+  val nonEmptyListSrc = "src/test/resources/samples/verification/NonEmptyList.def"
+  val nonEmptyListLocation = LocationPath(nonEmptyListSrc)
+  val validNonEmptyList = Root(Seq(
+    Verification(
+      name = "NonEmptyList",
+      message = "The list should not be empty",
+      function = DefinedFunction(
+        parameters = Seq(ParameterDefinition("list", TypeReference("List", Seq(TypeReference("A"))), nonEmptyListLocation(3, 7, 20))),
+        body = MethodCall(
+          expression = Reference("list", TypeReference("List", Seq(TypeReference("A"))), nonEmptyListLocation(4, 5, 9)),
+          method = "nonEmpty",
+          parameters = Seq.empty,
+          generics = Seq.empty,
+          returnType = TypeReference("Boolean"),
+          location = nonEmptyListLocation(4, 5, 20)
+        ),
+        genericTypes = Seq("A"),
+        location = nonEmptyListLocation(3, 3, 5, 4)
+      ),
+      comment = None,
+      location = nonEmptyListLocation(1, 1, 6, 2)
+    )
+  ))
+}


### PR DESCRIPTION
Generic types were not recognized in verification and named functions.
The syntax did explicit them, but the validation system refused them afterward.

The issue was in two parts:

* Typing did not encapsulate specific context
* Contexts did not check generics when searching for a type

The correction is about this two problems.

This commit do the following:

* Main:
    * Create specific context (use existing classes) for named functions, classes and verifications
    * In `Context.findType`, take into account generics
* Test:
    * Create helper `LocationPath` to simplify location specification
    * Add matchers `valid` and `invalid` to check the validation without checking the value
    * Add two tests to check generics into verification and named functions

This PR resolves #36 