### PR TITLE
[#40] It is now possible to have generics with alias type

### DIFF
--- a/src/main/scala/definiti/core/validation/NamedFunctionValidation.scala
+++ b/src/main/scala/definiti/core/validation/NamedFunctionValidation.scala
@@ -7,6 +7,6 @@ private[core] trait NamedFunctionValidation {
   self: ASTValidation =>
 
   protected def validateNamedFunction(namedFunction: NamedFunction): Validation = {
-    validateTypeReference(namedFunction.returnType, namedFunction.location)
+    validateTypeReference(namedFunction.returnType, namedFunction.genericTypes, namedFunction.location)
   }
 }

--- a/src/main/scala/definiti/core/validation/TypeValidation.scala
+++ b/src/main/scala/definiti/core/validation/TypeValidation.scala
@@ -7,20 +7,20 @@ private[core] trait TypeValidation {
   self: ASTValidation =>
 
   protected def validateAliasType(aliasType: AliasType): Validation = {
-    validateTypeReference(aliasType.alias, aliasType.location).verifyingAlso {
+    validateTypeReference(aliasType.alias, aliasType.genericTypes, aliasType.location).verifyingAlso {
       Validation.join(aliasType.inherited.map(validateVerificationReference(_, aliasType.location)))
     }
   }
 
   protected def validateDefinedType(definedType: DefinedType): Validation = {
     val inheritedValidations = definedType.inherited.map(validateVerificationReference(_, definedType.location))
-    val attributeValidations = definedType.attributes.map(validateAttributeDefinition)
+    val attributeValidations = definedType.attributes.map(validateAttributeDefinition(_, definedType.genericTypes))
     val verificationValidations = definedType.verifications.map(validateTypeVerification)
     Validation.join(inheritedValidations ++ attributeValidations ++ verificationValidations)
   }
 
-  private def validateAttributeDefinition(attribute: AttributeDefinition): Validation = {
-    val typeReferenceValidation = validateTypeReference(attribute.typeReference, attribute.location)
+  private def validateAttributeDefinition(attribute: AttributeDefinition, genericTypes: Seq[String]): Validation = {
+    val typeReferenceValidation = validateTypeReference(attribute.typeReference, genericTypes, attribute.location)
     val verificationsValidation = attribute.verifications.map(validateVerificationReference(_, attribute.location))
     Validation.join(typeReferenceValidation +: verificationsValidation)
   }

--- a/src/test/resources/samples/aliasTypes/ListAlias.def
+++ b/src/test/resources/samples/aliasTypes/ListAlias.def
@@ -1,0 +1,1 @@
+type ListAlias[A] = List[A]

--- a/src/test/scala/definiti/core/end2end/AliasTypeSpec.scala
+++ b/src/test/scala/definiti/core/end2end/AliasTypeSpec.scala
@@ -1,0 +1,11 @@
+package definiti.core.end2end
+
+import definiti.core.ValidationMatchers.valid
+import definiti.core.ast.Root
+
+class AliasTypeSpec extends EndToEndSpec {
+  "Project.generatePublicAST" should "generate the AST with an alias containing generics" in {
+    val output = processFile("aliasTypes.ListAlias")
+    output shouldBe valid[Root]
+  }
+}


### PR DESCRIPTION
Because of a bug, generics in alias types were not possible.
`validateTypeReference` ignored generic types in outer context.
Because of that, for all types, type reference could not be found
when generics were involved.

This commit do the following:

* Main:
    * Require `genericTypes` from outer context in `validateTypeReference`
    * Push this parameter in all callers
    * Remove unused `validateParameterDefinition` and `validateAbstractTypeReference`
* Test:
    * Add test to check generics into alias types