### PR TITLE
[#43] Accept executables instead of scala plugins only

### DIFF
--- a/src/main/scala/definiti/core/Plugin.scala
+++ b/src/main/scala/definiti/core/Plugin.scala
@@ -27,4 +27,8 @@ trait ContextPlugin[A] extends Plugin {
   def parse(content: String, location: Location): A
 
   def validate(context: A, library: Library): Validation
+
+  def contextToJson(context: A): String
+
+  def contextFromJson(json: String): A
 }

--- a/src/main/scala/definiti/core/plugin/CommandPlugin.scala
+++ b/src/main/scala/definiti/core/plugin/CommandPlugin.scala
@@ -1,0 +1,80 @@
+package definiti.core.plugin
+
+import java.nio.file.Path
+
+import definiti.core._
+import definiti.core.ast.pure.PureRoot
+import definiti.core.ast.{Library, Root}
+import definiti.core.plugin.serialization.JsonSerialization
+
+import scala.collection.mutable.ListBuffer
+import scala.sys.process._
+
+class ParserCommandPlugin(command: String, jsonSerialization: JsonSerialization) extends ParserPlugin {
+  override def name: String = command
+
+  private val commandPath: String = if (command.startsWith("./")) command else s"./${command}"
+
+  override def transform(root: PureRoot): Validated[PureRoot] = {
+    Command.execute(commandPath, "transform", jsonSerialization.pureRootToJson(root)) match {
+      case CommandResult(0, out, _) => ValidValue(jsonSerialization.pureRootFromJson(out))
+      case CommandResult(_, out, _) => jsonSerialization.invalidFromJson(out)
+    }
+  }
+}
+
+class ValidatorCommandPlugin(command: String, jsonSerialization: JsonSerialization) extends ValidatorPlugin {
+  override def name: String = command
+
+  private val commandPath: String = if (command.startsWith("./")) command else s"./${command}"
+
+  override def validate(root: Root, library: Library): Validation = {
+    Command.execute(commandPath, "validate", jsonSerialization.rootToJson(root), jsonSerialization.libraryToJson(library)) match {
+      case CommandResult(0, _, _) => Valid
+      case CommandResult(_, out, _) => jsonSerialization.invalidFromJson(out)
+    }
+  }
+}
+
+class GeneratorCommandPlugin(command: String, jsonSerialization: JsonSerialization) extends GeneratorPlugin {
+  override def name: String = command
+
+  private val commandPath: String = if (command.startsWith("./")) command else s"./${command}"
+
+  override def generate(root: Root, library: Library): Map[Path, String] = {
+    Command.execute(commandPath, "generate", jsonSerialization.rootToJson(root), jsonSerialization.libraryToJson(library)) match {
+      case CommandResult(0, out, _) => jsonSerialization.filesFromJson(out)
+      case _ => Map.empty
+    }
+  }
+}
+
+case class CommandResult(status: Int, out: String, err: String)
+
+object Command {
+  def execute(command: String, arguments: String*): CommandResult = {
+    val logger = new CommandPluginProcessLogger
+    val status = (command +: arguments).!(logger)
+    CommandResult(status, logger.outString, logger.errString)
+  }
+
+  private class CommandPluginProcessLogger extends ProcessLogger {
+    private val outBuffer = new ListBuffer[String]
+    private val errBuffer = new ListBuffer[String]
+
+    def out: Seq[String] = outBuffer.toList
+
+    def outString: String = out.mkString("\n")
+
+    def err: Seq[String] = errBuffer.toList
+
+    def errString: String = err.mkString("\n")
+
+    override def out(s: => String): Unit = outBuffer.append(s)
+
+    override def err(s: => String): Unit = errBuffer.append(s)
+
+    override def buffer[T](f: => T): T = f
+  }
+
+}

--- a/src/main/scala/definiti/core/plugin/serialization/GeneratorSerialization.scala
+++ b/src/main/scala/definiti/core/plugin/serialization/GeneratorSerialization.scala
@@ -1,0 +1,32 @@
+package definiti.core.plugin.serialization
+
+import java.nio.file.{Path, Paths}
+
+import spray.json._
+
+trait GeneratorSerialization {
+  self: JsonSerialization =>
+
+  def filesFromJson(json: String): Map[Path, String] = {
+    val jsValue = json.parseJson
+    jsValue match {
+      case JsObject(fields) =>
+        fields.map { case (path, contentJsValue) =>
+          contentJsValue match {
+            case JsString(content) => createPath(path) -> content
+            case _ => deserializationError(s"Expected string, got: ${contentJsValue}")
+          }
+        }
+      case _ => deserializationError(s"Expected object, got: ${jsValue}")
+    }
+  }
+
+  private def createPath(str: String): Path = {
+    val path = Paths.get(str)
+    if (!path.isAbsolute && !str.startsWith(".")) {
+      Paths.get(".", str)
+    } else {
+      path
+    }
+  }
+}

--- a/src/main/scala/definiti/core/plugin/serialization/JsonSerialization.scala
+++ b/src/main/scala/definiti/core/plugin/serialization/JsonSerialization.scala
@@ -1,0 +1,62 @@
+package definiti.core.plugin.serialization
+
+import definiti.core.Configuration
+import spray.json._
+
+class JsonSerialization(val config: Configuration)
+  extends GeneratorSerialization
+    with LibrarySerialization
+    with PureRootJsonSerialization
+    with RootJsonSerialization
+    with ValidationJsonSerialization {
+
+  def sealedTraitFormat[A](formats: Format[_ <: A]*): JsonFormat[A] = new JsonFormat[A] {
+    override def write(obj: A): JsValue = {
+      formats.flatMap(_.writeOpt(obj)).headOption match {
+        case Some(value) => value
+        case None => serializationError(s"Unknown format for type ${obj.getClass}")
+      }
+    }
+
+    override def read(json: JsValue): A = {
+      formats.flatMap(_.readOpt(json)).headOption match {
+        case Some(value) => value
+        case None => deserializationError(s"Could not read sealed trait from ${json}")
+      }
+    }
+  }
+
+  def enumerationFormat[A <: Enumeration](enumeration: A): JsonFormat[A#Value] = new JsonFormat[A#Value] {
+    override def write(obj: A#Value): JsValue = {
+      JsString(obj.toString)
+    }
+
+    override def read(json: JsValue): A#Value = {
+      json match {
+        case JsString(txt) => enumeration.withName(txt)
+        case other => deserializationError(s"Expected ${enumeration}, got: ${other}")
+      }
+    }
+  }
+}
+
+case class Format[A](typ: String, clazz: Class[A])(implicit jsonFormat: JsonFormat[A]) {
+  def writeOpt[B >: A](value: B): Option[JsValue] = {
+    if (value.getClass == clazz) {
+      val jsValue = jsonFormat.write(value.asInstanceOf[A]) match {
+        case JsObject(fields) => JsObject(fields ++ Map("type" -> JsString(typ)))
+        case other => other
+      }
+      Some(jsValue)
+    } else {
+      None
+    }
+  }
+
+  def readOpt(json: JsValue): Option[A] = {
+    json match {
+      case JsObject(fields) if fields.get("type").contains(JsString(typ)) => Some(jsonFormat.read(json))
+      case _ => None
+    }
+  }
+}

--- a/src/main/scala/definiti/core/plugin/serialization/LibrarySerialization.scala
+++ b/src/main/scala/definiti/core/plugin/serialization/LibrarySerialization.scala
@@ -1,0 +1,24 @@
+package definiti.core.plugin.serialization
+
+
+import definiti.core.ast.Library
+import spray.json.{JsArray, JsObject, JsString}
+
+trait LibrarySerialization {
+  self: JsonSerialization =>
+
+  def libraryToJson(library: Library): String = {
+    JsObject(
+      field("packages", library.packages),
+      field("verifications", library.verifications),
+      field("types", library.types),
+      field("attributes", library.attributes),
+      field("methods", library.methods),
+      field("namedFunctions", library.namedFunctions)
+    ).compactPrint
+  }
+
+  private def field(name: String, elements: Map[String, _]): (String, JsArray) = {
+    name -> JsArray(elements.keys.map(JsString(_)).toVector)
+  }
+}

--- a/src/main/scala/definiti/core/plugin/serialization/PureRootJsonSerialization.scala
+++ b/src/main/scala/definiti/core/plugin/serialization/PureRootJsonSerialization.scala
@@ -1,0 +1,94 @@
+package definiti.core.plugin.serialization
+
+import definiti.core.ContextPlugin
+import definiti.core.ast.Location
+import definiti.core.ast.pure._
+import spray.json._
+
+trait PureRootJsonSerialization {
+  self: JsonSerialization =>
+
+  def pureRootToJson(pureRoot: PureRoot): String = pureRootFormat.write(pureRoot).compactPrint
+
+  def pureRootFromJson(json: String): PureRoot = pureRootFormat.read(json.parseJson)
+
+  import spray.json.DefaultJsonProtocol._
+
+  implicit lazy val pureRootFormat: JsonFormat[PureRoot] = lazyFormat(jsonFormat1(PureRoot.apply))
+  implicit lazy val pureRootFileFormat: JsonFormat[PureRootFile] = lazyFormat(jsonFormat6(PureRootFile.apply))
+  implicit lazy val pureClassDefinitionFormat: JsonFormat[PureClassDefinition] = lazyFormat(sealedTraitFormat[PureClassDefinition](
+    Format("aliasType", classOf[PureAliasType]),
+    Format("definedType", classOf[PureDefinedType]),
+    Format("nativeClassDefinition", classOf[PureNativeClassDefinition])
+  ))
+  implicit lazy val pureNativeClassDefinitionFormat: JsonFormat[PureNativeClassDefinition] = lazyFormat(jsonFormat5(PureNativeClassDefinition.apply))
+  implicit lazy val pureDefinedFunctionFormat: JsonFormat[PureDefinedFunction] = lazyFormat(jsonFormat4(PureDefinedFunction.apply))
+  implicit lazy val pureParameterFormat: JsonFormat[PureParameter] = lazyFormat(jsonFormat3(PureParameter.apply))
+  implicit lazy val pureVerificationFormat: JsonFormat[PureVerification] = lazyFormat(jsonFormat6(PureVerification.apply))
+  implicit lazy val pureTypeFormat: JsonFormat[PureType] = lazyFormat(sealedTraitFormat[PureType](
+    Format("aliasType", classOf[PureAliasType]),
+    Format("definedType", classOf[PureDefinedType])
+  ))
+  implicit lazy val pureDefinedTypeFormat: JsonFormat[PureDefinedType] = lazyFormat(jsonFormat8(PureDefinedType.apply))
+  implicit lazy val pureAliasTypeFormat: JsonFormat[PureAliasType] = lazyFormat(jsonFormat7(PureAliasType.apply))
+  implicit lazy val pureTypeVerificationFormat: JsonFormat[PureTypeVerification] = lazyFormat(jsonFormat3(PureTypeVerification.apply))
+  implicit lazy val pureNamedFunctionFormat: JsonFormat[PureNamedFunction] = lazyFormat(jsonFormat7(PureNamedFunction.apply))
+  implicit lazy val pureExtendedContextFormat: JsonFormat[PureExtendedContext[_]] = lazyFormat(new JsonFormat[PureExtendedContext[_]] {
+    override def write(obj: PureExtendedContext[_]): JsValue = {
+      val contextPlugin = config.contexts
+        .find(_.contextName == obj.name)
+        .getOrElse(deserializationError(s"Unknown context ${obj.name}"))
+        .asInstanceOf[ContextPlugin[Any]]
+      JsObject(
+        "name" -> obj.name.toJson,
+        "content" -> contextPlugin.contextToJson(obj.content).parseJson,
+        "location" -> obj.location.toJson
+      )
+    }
+
+    override def read(json: JsValue): PureExtendedContext[_] = {
+      json match {
+        case JsObject(fields) =>
+          val name = fields.get("name").map(_.convertTo[String]).getOrElse(deserializationError("Undefined field name"))
+          val contextPlugin = config.contexts
+            .find(_.contextName == name)
+            .getOrElse(deserializationError(s"Unknown context ${name}"))
+          PureExtendedContext(
+            name = name,
+            content = fields.get("content").map(content => contextPlugin.contextFromJson(content.compactPrint)).getOrElse(deserializationError("Undefined field content")),
+            location = fields.get("location").map(_.convertTo[Location]).getOrElse(deserializationError("Undefined field location"))
+          )
+        case _ => deserializationError(s"Object expected, got: ${json}")
+      }
+    }
+  })
+
+  implicit lazy val pureExpressionFormat: JsonFormat[PureExpression] = lazyFormat(sealedTraitFormat[PureExpression](
+    Format("logicalExpression", classOf[PureLogicalExpression]),
+    Format("calculatorExpression", classOf[PureCalculatorExpression]),
+    Format("not", classOf[PureNot]),
+    Format("booleanValue", classOf[PureBooleanValue]),
+    Format("numberValue", classOf[PureNumberValue]),
+    Format("quotedStringValue", classOf[PureQuotedStringValue]),
+    Format("reference", classOf[PureReference]),
+    Format("methodCall", classOf[PureMethodCall]),
+    Format("attributeCall", classOf[PureAttributeCall]),
+    Format("combinedExpression", classOf[PureCombinedExpression]),
+    Format("condition", classOf[PureCondition]),
+    Format("lambdaExpression", classOf[PureLambdaExpression]),
+    Format("functionCall", classOf[PureFunctionCall])
+  ))
+  implicit lazy val pureLogicalExpressionFormat: JsonFormat[PureLogicalExpression] = lazyFormat(jsonFormat4(PureLogicalExpression.apply))
+  implicit lazy val pureCalculatorExpressionFormat: JsonFormat[PureCalculatorExpression] = lazyFormat(jsonFormat4(PureCalculatorExpression.apply))
+  implicit lazy val pureNotFormat: JsonFormat[PureNot] = lazyFormat(jsonFormat2(PureNot.apply))
+  implicit lazy val pureBooleanValueFormat: JsonFormat[PureBooleanValue] = lazyFormat(jsonFormat2(PureBooleanValue.apply))
+  implicit lazy val pureNumberValueFormat: JsonFormat[PureNumberValue] = lazyFormat(jsonFormat2(PureNumberValue.apply))
+  implicit lazy val pureQuotedStringValueFormat: JsonFormat[PureQuotedStringValue] = lazyFormat(jsonFormat2(PureQuotedStringValue.apply))
+  implicit lazy val pureReferenceFormat: JsonFormat[PureReference] = lazyFormat(jsonFormat2(PureReference.apply))
+  implicit lazy val pureMethodCallFormat: JsonFormat[PureMethodCall] = lazyFormat(jsonFormat5(PureMethodCall.apply))
+  implicit lazy val pureAttributeCallFormat: JsonFormat[PureAttributeCall] = lazyFormat(jsonFormat3(PureAttributeCall.apply))
+  implicit lazy val pureCombinedExpressionFormat: JsonFormat[PureCombinedExpression] = lazyFormat(jsonFormat2(PureCombinedExpression.apply))
+  implicit lazy val pureConditionFormat: JsonFormat[PureCondition] = lazyFormat(jsonFormat4(PureCondition.apply))
+  implicit lazy val pureLambdaExpressionFormat: JsonFormat[PureLambdaExpression] = lazyFormat(jsonFormat3(PureLambdaExpression.apply))
+  implicit lazy val pureFunctionCallFormat: JsonFormat[PureFunctionCall] = lazyFormat(jsonFormat4(PureFunctionCall.apply))
+}

--- a/src/main/scala/definiti/core/plugin/serialization/RootJsonSerialization.scala
+++ b/src/main/scala/definiti/core/plugin/serialization/RootJsonSerialization.scala
@@ -1,0 +1,87 @@
+package definiti.core.plugin.serialization
+
+import definiti.core.ast._
+import spray.json._
+
+trait RootJsonSerialization {
+  self: JsonSerialization =>
+
+  def rootToJson(root: Root): String = {
+    rootFormat.write(root).compactPrint
+  }
+
+  def rootFromJson(json: String): Root = {
+    rootFormat.read(json.parseJson)
+  }
+
+  import spray.json.DefaultJsonProtocol._
+
+  implicit lazy val rootFormat: JsonFormat[Root] = lazyFormat(jsonFormat1(Root.apply))
+  implicit lazy val namespaceElementFormat: JsonFormat[NamespaceElement] = lazyFormat(sealedTraitFormat[NamespaceElement](
+    Format("aliasType", classOf[AliasType]),
+    Format("definedType", classOf[DefinedType]),
+    Format("nativeClassDefinition", classOf[NativeClassDefinition]),
+    Format("namedFunction", classOf[NamedFunction]),
+    Format("namespace", classOf[Namespace]),
+    Format("verification", classOf[Verification])
+  ))
+  implicit lazy val namespaceFormat: JsonFormat[Namespace] = lazyFormat(jsonFormat3(Namespace.apply))
+  implicit lazy val verificationFormat: JsonFormat[Verification] = lazyFormat(jsonFormat5(Verification.apply))
+  implicit lazy val classDefinitionFormat: JsonFormat[ClassDefinition] = lazyFormat(sealedTraitFormat[ClassDefinition](
+    Format("aliasType", classOf[AliasType]),
+    Format("definedType", classOf[DefinedType]),
+    Format("nativeClassDefinition", classOf[NativeClassDefinition])
+  ))
+  implicit lazy val definedTypeFormat: JsonFormat[DefinedType] = lazyFormat(jsonFormat7(DefinedType.apply))
+  implicit lazy val aliasTypeFormat: JsonFormat[AliasType] = lazyFormat(jsonFormat6(AliasType.apply))
+  implicit lazy val nativeClassDefinitionFormat: JsonFormat[NativeClassDefinition] = lazyFormat(jsonFormat5(NativeClassDefinition.apply))
+  implicit lazy val namedFunctionFormat: JsonFormat[NamedFunction] = lazyFormat(jsonFormat6(NamedFunction.apply))
+
+  implicit lazy val abstractTypeReferenceFormat: JsonFormat[AbstractTypeReference] = lazyFormat(sealedTraitFormat[AbstractTypeReference](
+    Format("typeReference", classOf[TypeReference]),
+    Format("lambdaReference", classOf[LambdaReference]),
+    Format("namedFunctionReference", classOf[NamedFunctionReference])
+  ))
+  implicit lazy val typeReferenceFormat: JsonFormat[TypeReference] = lazyFormat(jsonFormat2(TypeReference.apply))
+  implicit lazy val lambdaReferenceFormat: JsonFormat[LambdaReference] = lazyFormat(jsonFormat2(LambdaReference.apply))
+  implicit lazy val namedFunctionReferenceFormat: JsonFormat[NamedFunctionReference] = lazyFormat(jsonFormat1(NamedFunctionReference.apply))
+  implicit lazy val attributeDefinitionFormat: JsonFormat[AttributeDefinition] = lazyFormat(jsonFormat5(AttributeDefinition.apply))
+  implicit lazy val parameterDefinitionFormat: JsonFormat[ParameterDefinition] = lazyFormat(jsonFormat3(ParameterDefinition.apply))
+  implicit lazy val methodDefinitionFormat: JsonFormat[MethodDefinition] = lazyFormat(jsonFormat5(MethodDefinition.apply))
+  implicit lazy val verificationReferenceFormat: JsonFormat[VerificationReference] = lazyFormat(jsonFormat3(VerificationReference.apply))
+  implicit lazy val typeVerificationFormat: JsonFormat[TypeVerification] = lazyFormat(jsonFormat3(TypeVerification.apply))
+  implicit lazy val definedFunctionFormat: JsonFormat[DefinedFunction] = lazyFormat(jsonFormat4(DefinedFunction.apply))
+  implicit lazy val parameterFormat: JsonFormat[Parameter] = lazyFormat(jsonFormat3(Parameter.apply))
+
+  implicit lazy val expressionFormat: JsonFormat[Expression] = lazyFormat(sealedTraitFormat(
+    Format("logicalExpression", classOf[LogicalExpression]),
+    Format("not", classOf[Not]),
+    Format("booleanValue", classOf[BooleanValue]),
+    Format("numberValue", classOf[NumberValue]),
+    Format("quotedStringValue", classOf[QuotedStringValue]),
+    Format("reference", classOf[Reference]),
+    Format("methodCall", classOf[MethodCall]),
+    Format("attributeCall", classOf[AttributeCall]),
+    Format("combinedExpression", classOf[CombinedExpression]),
+    Format("condition", classOf[Condition]),
+    Format("lambdaExpression", classOf[LambdaExpression]),
+    Format("functionCall", classOf[FunctionCall])
+  ))
+  implicit lazy val logicalExpressionFormat: JsonFormat[LogicalExpression] = lazyFormat(jsonFormat5(LogicalExpression.apply))
+  implicit lazy val notFormat: JsonFormat[Not] = lazyFormat(jsonFormat3(Not.apply))
+  implicit lazy val booleanValueFormat: JsonFormat[BooleanValue] = lazyFormat(jsonFormat3(BooleanValue.apply))
+  implicit lazy val numberValueFormat: JsonFormat[NumberValue] = lazyFormat(jsonFormat3(NumberValue.apply))
+  implicit lazy val quotedStringValueFormat: JsonFormat[QuotedStringValue] = lazyFormat(jsonFormat3(QuotedStringValue.apply))
+  implicit lazy val referenceFormat: JsonFormat[Reference] = lazyFormat(jsonFormat3(Reference.apply))
+  implicit lazy val methodCallFormat: JsonFormat[MethodCall] = lazyFormat(jsonFormat6(MethodCall.apply))
+  implicit lazy val attributeCallFormat: JsonFormat[AttributeCall] = lazyFormat(jsonFormat4(AttributeCall.apply))
+  implicit lazy val combinedExpressionFormat: JsonFormat[CombinedExpression] = lazyFormat(jsonFormat3(CombinedExpression.apply))
+  implicit lazy val conditionFormat: JsonFormat[Condition] = lazyFormat(jsonFormat5(Condition.apply))
+  implicit lazy val lambdaExpressionFormat: JsonFormat[LambdaExpression] = lazyFormat(jsonFormat4(LambdaExpression.apply))
+  implicit lazy val functionCallFormat: JsonFormat[FunctionCall] = lazyFormat(jsonFormat5(FunctionCall.apply))
+  implicit lazy val logicalOperatorFormat: JsonFormat[LogicalOperator.Value] = lazyFormat(enumerationFormat(LogicalOperator))
+  implicit lazy val calculatorOperatorFormat: JsonFormat[CalculatorOperator.Value] = lazyFormat(enumerationFormat(CalculatorOperator))
+  implicit lazy val locationFormat: JsonFormat[Location] = lazyFormat(jsonFormat2(Location.apply))
+  implicit lazy val rangeFormat: JsonFormat[Range] = lazyFormat(jsonFormat2(Range.apply))
+  implicit lazy val positionFormat: JsonFormat[Position] = lazyFormat(jsonFormat2(Position.apply))
+}

--- a/src/main/scala/definiti/core/plugin/serialization/ValidationJsonSerialization.scala
+++ b/src/main/scala/definiti/core/plugin/serialization/ValidationJsonSerialization.scala
@@ -1,0 +1,39 @@
+package definiti.core.plugin.serialization
+
+import definiti.core.{ASTError, Error, Invalid, SimpleError}
+import spray.json._
+
+trait ValidationJsonSerialization {
+  self: JsonSerialization =>
+
+  def invalidFromJson(value: String): Invalid = {
+    Invalid(seqErrorReader.read(value.parseJson))
+  }
+
+  import spray.json.DefaultJsonProtocol._
+
+  private lazy val astErrorMessageFormat: JsonFormat[ASTError] = jsonFormat2(ASTError.apply)
+  private lazy val simpleErrorMessageFormat: JsonFormat[SimpleError] = new JsonFormat[SimpleError] {
+    override def read(json: JsValue): SimpleError = json match {
+      case JsString(value) => SimpleError(value)
+      case _ => deserializationError(s"Expected string, got: ${json}")
+    }
+
+    override def write(obj: SimpleError): JsValue = JsString(obj.message)
+  }
+  private lazy val errorFormat: JsonFormat[Error] = new JsonFormat[Error] {
+    override def write(error: Error): JsValue = error match {
+      case astError: ASTError => astErrorMessageFormat.write(astError)
+      case simpleError: SimpleError => simpleErrorMessageFormat.write(simpleError)
+    }
+
+    override def read(json: JsValue): Error = {
+      json match {
+        case _: JsObject => astErrorMessageFormat.read(json)
+        case _: JsString => simpleErrorMessageFormat.read(json)
+        case _ => deserializationError(s"Object or String expected, got: ${json}")
+      }
+    }
+  }
+  private lazy val seqErrorReader: JsonFormat[Seq[Error]] = seqFormat[Error](errorFormat)
+}

--- a/src/test/scala/definiti/core/mock/plugins/StringExtendedContext.scala
+++ b/src/test/scala/definiti/core/mock/plugins/StringExtendedContext.scala
@@ -11,4 +11,8 @@ class StringExtendedContext extends ContextPlugin[String] {
   override def validate(context: String, library: Library): Valid.type = Valid
 
   override def name = "stringContext"
+
+  override def contextToJson(context: String) = context
+
+  override def contextFromJson(json: String) = json
 }

--- a/src/test/scala/definiti/core/parser/project/ProcessContextSpec.scala
+++ b/src/test/scala/definiti/core/parser/project/ProcessContextSpec.scala
@@ -42,6 +42,10 @@ object ProcessContextSpec {
     }
 
     override def name: String = "MyContextPlugin"
+
+    override def contextToJson(context: ContextPluginTestContent) = "{}"
+
+    override def contextFromJson(json: String) = ContextPluginTestContent(json, Location("", 0, 0, 0, 0))
   }
 
 }


### PR DESCRIPTION
Because Definiti should be used to generate codes in several languages,
having a strong dependency on one language is not quite logic.

Now we can accept binary files to transform or validate AST or generate files.

The interface is nearly the same as scala plugin,
but as command line arguments instead of interface methods.

A try was done with JNA without success because of polymorphism.
We fallback to a version as arguments in json.

This commit does the following:

* Create JSON serialization for AST (pure and final) and library
* ContextPlugin interface need to change to define how to serialize json
* Create a class to create instance of command-line plugins
* Dependencies are accepted as command line with prefix `>` so we change configuration

Remark: Only tested into linux embedded in windows.
We should confirm it works in docker container.

This pull request closes #43.

# Impact in global project

This Pull Request only accept binary file for linux environments. Whatever is the language of the plugin, it will need to be converted into a binary file.
For JVM languages, plugin interfaces still exist, but the command line should be updated to avoid rebuilding the whole project each time.