### PR TITLE
[#44] Add enumeration system

### DIFF
--- a/src/main/antlr/Definiti.g4
+++ b/src/main/antlr/Definiti.g4
@@ -10,13 +10,7 @@ VERIFY       : 'verify';
 VERIFYING    : 'verifying';
 DEF          : 'def';
 CONTEXT      : 'context';
-
-REQUIREMENT : 'requirement';
-REQUEST     : 'request';
-WITH        : 'with';
-REQUIRING   : 'requiring';
-ABORT       : 'abort';
-RETURNING   : 'returning';
+ENUM         : 'enum';
 
 BOOLEAN                      : 'true' | 'false';
 NUMBER                       : [0-9]+('.'[0-9]+)?;
@@ -44,6 +38,7 @@ toplevel
   : verification
   | definedType
   | aliasType
+  | enumType
   | namedFunction
   | context
   ;
@@ -99,9 +94,15 @@ typeVerification:
 
 typeVerificationFunction: '(' IDENTIFIER ')' '=>' '{' chainedExpression '}';
 
-aliasType :
+aliasType:
   DOC_COMMENT?
   TYPE typeName=IDENTIFIER ('[' genericTypes=genericTypeList ']')? '=' referenceTypeName=IDENTIFIER ('[' aliasGenericTypes=genericTypeList ']')? verifyingList;
+
+enumType:
+  DOC_COMMENT?
+  ENUM typeName=IDENTIFIER '{' enumCase* '}';
+
+enumCase: DOC_COMMENT? IDENTIFIER;
 
 function : ('[' genericTypeList ']')? '(' parameterListDefinition ')' '=>' '{' chainedExpression '}';
 
@@ -150,12 +151,6 @@ contextContentSymbol
   | VERIFYING
   | DEF
   | CONTEXT
-  | REQUIREMENT
-  | REQUEST
-  | WITH
-  | REQUIRING
-  | ABORT
-  | RETURNING
   | '.'
   | ':'
   | '(' | ')'

--- a/src/main/resources/samples/src2/alarm.def
+++ b/src/main/resources/samples/src2/alarm.def
@@ -1,0 +1,26 @@
+package my.alarm
+
+enum Day {
+  monday
+  tuesday
+  wednesday
+  thursday
+  friday
+  saturday
+  sunday
+}
+
+type Alarm {
+  name: String
+  hour: Number
+  minute: Number
+  days: List[Day]
+}
+
+def isWeekend(day: Day): Boolean => {
+  day == Day.saturday || day == Day.sunday
+}
+
+def dayIdentity(day: Day): Day => {
+  day
+}

--- a/src/main/scala/definiti/core/Context.scala
+++ b/src/main/scala/definiti/core/Context.scala
@@ -60,6 +60,16 @@ private[core] case class ReferenceContext(
   }
 
   override def findTypeReference(name: String): Option[AbstractTypeReference] = {
+    findClassReference(name).orElse(findNamedFunctionReference(name))
+  }
+
+  private def findClassReference(name: String): Option[AbstractTypeReference] = {
+    classes
+      .find(_.canonicalName == name)
+      .map(_ => TypeReference(name))
+  }
+
+  private def findNamedFunctionReference(name: String): Option[AbstractTypeReference] = {
     namedFunctions
       .find(_.canonicalName == name)
       .map(_ => NamedFunctionReference(name))

--- a/src/main/scala/definiti/core/ast/AST.scala
+++ b/src/main/scala/definiti/core/ast/AST.scala
@@ -53,6 +53,21 @@ case class NativeClassDefinition(
   comment: Option[String]
 ) extends ClassDefinition
 
+case class Enum(
+  name: String,
+  cases: Seq[EnumCase],
+  comment: Option[String],
+  location: Location
+) extends ClassDefinition {
+  override def genericTypes: Seq[String] = Seq.empty
+}
+
+case class EnumCase(
+  name: String,
+  comment: Option[String],
+  location: Location
+)
+
 case class NamedFunction(
   name: String,
   genericTypes: Seq[String],

--- a/src/main/scala/definiti/core/ast/pure/AST.scala
+++ b/src/main/scala/definiti/core/ast/pure/AST.scala
@@ -56,6 +56,24 @@ private[core] case class PureAliasType(name: String, packageName: String, generi
   override def canonicalName: String = ASTHelper.canonical(packageName, name)
 }
 
+private[core] case class PureEnum(
+  name: String,
+  packageName: String,
+  cases: Seq[PureEnumCase],
+  comment: Option[String],
+  location: Location
+) extends PureClassDefinition {
+  override def canonicalName: String = ASTHelper.canonical(packageName, name)
+
+  override def genericTypes: Seq[String] = Seq.empty
+}
+
+private[core] case class PureEnumCase(
+  name: String,
+  comment: Option[String],
+  location: Location
+)
+
 private[core] case class PureTypeVerification(message: String, function: PureDefinedFunction, location: Location)
 
 private[core] case class PureNamedFunction(

--- a/src/main/scala/definiti/core/ast/typed/AST.scala
+++ b/src/main/scala/definiti/core/ast/typed/AST.scala
@@ -50,6 +50,24 @@ private[core] case class TypedAliasType(name: String, packageName: String, gener
   override def canonicalName: String = ASTHelper.canonical(packageName, name)
 }
 
+private[core] case class TypedEnum(
+  name: String,
+  packageName: String,
+  cases: Seq[TypedEnumCase],
+  comment: Option[String],
+  location: Location
+) extends Type {
+  override def canonicalName: String = ASTHelper.canonical(packageName, name)
+
+  override def genericTypes: Seq[String] = Seq.empty
+}
+
+private[core] case class TypedEnumCase(
+  name: String,
+  comment: Option[String],
+  location: Location
+)
+
 private[core] case class TypedNamedFunction(
   name: String,
   packageName: String,

--- a/src/main/scala/definiti/core/linking/ProjectLinking.scala
+++ b/src/main/scala/definiti/core/linking/ProjectLinking.scala
@@ -85,6 +85,8 @@ private[core] object ProjectLinking {
           verifications = definedType.verifications.map(injectLinksIntoTypeVerification(_, typeMapping)),
           inherited = definedType.inherited.map(injectLinksIntoVerificationReference(_, typeMapping))
         )
+      case enum: PureEnum =>
+        enum.copy(packageName = packageName)
       case other => other
     }
   }

--- a/src/main/scala/definiti/core/parser/project/DefinitiASTParser.scala
+++ b/src/main/scala/definiti/core/parser/project/DefinitiASTParser.scala
@@ -23,6 +23,7 @@ private[core] class DefinitiASTParser(sourceFile: String, configuration: Configu
       appendIfDefined(element.verification(), verifications, processVerification)
       appendIfDefined(element.definedType(), classDefinitions, processDefinedType)
       appendIfDefined(element.aliasType(), classDefinitions, processAliasType)
+      appendIfDefined(element.enumType(), classDefinitions, processEnum)
       appendIfDefined(element.namedFunction(), namedFunctions, processNamedFunction)
       Option(element.context()).foreach { internalContext =>
         processContext(internalContext) match {
@@ -136,6 +137,24 @@ private[core] class DefinitiASTParser(sourceFile: String, configuration: Configu
       ),
       genericTypes = processGenericTypeListDefinition(context.genericTypes),
       inherited = processVerifyingList(context.verifyingList()),
+      comment = Option(context.DOC_COMMENT()).map(_.getText).map(extractDocComment),
+      location = getLocationFromContext(context)
+    )
+  }
+
+  def processEnum(context: EnumTypeContext): PureEnum = {
+    PureEnum(
+      name = context.typeName.getText,
+      packageName = NOT_DEFINED,
+      cases = scalaSeq(context.enumCase()).map(processEnumCase),
+      comment = Option(context.DOC_COMMENT()).map(_.getText).map(extractDocComment),
+      location = getLocationFromContext(context)
+    )
+  }
+
+  def processEnumCase(context: EnumCaseContext): PureEnumCase = {
+    PureEnumCase(
+      name = context.IDENTIFIER().getText,
       comment = Option(context.DOC_COMMENT()).map(_.getText).map(extractDocComment),
       location = getLocationFromContext(context)
     )

--- a/src/main/scala/definiti/core/plugin/serialization/PureRootJsonSerialization.scala
+++ b/src/main/scala/definiti/core/plugin/serialization/PureRootJsonSerialization.scala
@@ -32,6 +32,8 @@ trait PureRootJsonSerialization {
   implicit lazy val pureDefinedTypeFormat: JsonFormat[PureDefinedType] = lazyFormat(jsonFormat8(PureDefinedType.apply))
   implicit lazy val pureAliasTypeFormat: JsonFormat[PureAliasType] = lazyFormat(jsonFormat7(PureAliasType.apply))
   implicit lazy val pureTypeVerificationFormat: JsonFormat[PureTypeVerification] = lazyFormat(jsonFormat3(PureTypeVerification.apply))
+  implicit lazy val pureEnumFormat: JsonFormat[PureEnum] = lazyFormat(jsonFormat5(PureEnum.apply))
+  implicit lazy val pureEnumCaseFormat: JsonFormat[PureEnumCase] = lazyFormat(jsonFormat3(PureEnumCase.apply))
   implicit lazy val pureNamedFunctionFormat: JsonFormat[PureNamedFunction] = lazyFormat(jsonFormat7(PureNamedFunction.apply))
   implicit lazy val pureExtendedContextFormat: JsonFormat[PureExtendedContext[_]] = lazyFormat(new JsonFormat[PureExtendedContext[_]] {
     override def write(obj: PureExtendedContext[_]): JsValue = {

--- a/src/main/scala/definiti/core/structure/ProjectStructure.scala
+++ b/src/main/scala/definiti/core/structure/ProjectStructure.scala
@@ -86,6 +86,7 @@ private[core] class ProjectStructure(root: typed.TypedRoot) {
       case _: typed.TypedNativeClassDefinition => None
       case definedType: typed.TypedDefinedType => Some(transformDefinedType(definedType))
       case aliasType: typed.TypedAliasType => Some(transformAliasType(aliasType))
+      case enum: typed.TypedEnum => Some(transformEnum(enum))
     }
   }
 
@@ -109,6 +110,21 @@ private[core] class ProjectStructure(root: typed.TypedRoot) {
       inherited = aliasType.inherited,
       comment = aliasType.comment,
       location = aliasType.location
+    )
+  }
+
+  private def transformEnum(enum: typed.TypedEnum): Enum = {
+    Enum(
+      name = enum.name,
+      cases = enum.cases.map { enumCase =>
+        EnumCase(
+          name = enumCase.name,
+          comment = enumCase.comment,
+          location = enumCase.location
+        )
+      },
+      comment = enum.comment,
+      location = enum.location
     )
   }
 

--- a/src/main/scala/definiti/core/typing/ClassDefinitionTyping.scala
+++ b/src/main/scala/definiti/core/typing/ClassDefinitionTyping.scala
@@ -11,6 +11,7 @@ private[core] class ClassDefinitionTyping(context: Context) {
       case native: PureNativeClassDefinition => ValidValue(transformNativeClassDefinition(native))
       case definedType: PureDefinedType => addTypesIntoDefinedType(definedType)
       case aliasType: PureAliasType => ValidValue(transformAliasType(aliasType))
+      case enum: PureEnum => ValidValue(transformEnum(enum))
     }
   }
 
@@ -61,6 +62,22 @@ private[core] class ClassDefinitionTyping(context: Context) {
       inherited = aliasType.inherited,
       comment = aliasType.comment,
       location = aliasType.location
+    )
+  }
+
+  def transformEnum(enum: PureEnum): TypedEnum = {
+    TypedEnum(
+      name = enum.name,
+      packageName = enum.packageName,
+      cases = enum.cases.map { enumCase =>
+        TypedEnumCase(
+          name = enumCase.name,
+          comment = enumCase.comment,
+          location = enumCase.location
+        )
+      },
+      comment = enum.comment,
+      location = enum.location
     )
   }
 }

--- a/src/main/scala/definiti/core/typing/ExpressionTyping.scala
+++ b/src/main/scala/definiti/core/typing/ExpressionTyping.scala
@@ -155,6 +155,18 @@ private[core] class ExpressionTyping(context: Context) {
         context.findType(aliasType.alias.typeName).flatMap(getAttributeOpt(_, attribute))
       case definedType: PureDefinedType =>
         definedType.attributes.find(_.name == attribute)
+      case enum: PureEnum =>
+        enum.cases
+          .find(_.name == attribute)
+          .map { enumCase =>
+            AttributeDefinition(
+              name = enumCase.name,
+              typeReference = TypeReference(enum.canonicalName),
+              comment = enumCase.comment,
+              verifications = Seq.empty,
+              location = enumCase.location
+            )
+          }
     }
   }
 

--- a/src/main/scala/definiti/core/validation/ASTValidation.scala
+++ b/src/main/scala/definiti/core/validation/ASTValidation.scala
@@ -1,7 +1,7 @@
 package definiti.core.validation
 
 import definiti.core.ast._
-import definiti.core.{ast, _}
+import definiti.core._
 
 private[core] class ASTValidation(
   val configuration: Configuration,
@@ -26,6 +26,7 @@ private[core] class ASTValidation(
       case verification: Verification => validateVerification(verification)
       case definedType: DefinedType => validateDefinedType(definedType)
       case aliasType: AliasType => validateAliasType(aliasType)
+      case enum: Enum => validateEnum(enum)
       case namedFunction: NamedFunction => validateNamedFunction(namedFunction)
       case extendedContext: ExtendedContext[_] => validateExtendedContext(extendedContext, library)
     }

--- a/src/main/scala/definiti/core/validation/TypeValidation.scala
+++ b/src/main/scala/definiti/core/validation/TypeValidation.scala
@@ -28,4 +28,16 @@ private[core] trait TypeValidation {
   private def validateTypeVerification(verification: TypeVerification): Validation = {
     validateDeepBooleanExpression(verification.function.body)
   }
+
+  protected def validateEnum(enum: Enum): Validation = {
+    Validation.join {
+      enum.cases.zipWithIndex.map { case (enumCase, index) =>
+        if (enum.cases.indexWhere(_.name == enumCase.name) == index) {
+          Valid
+        } else {
+          Invalid(s"The case ${enumCase.name} is already defined in enum ${enum.name}", enumCase.location)
+        }
+      }
+    }
+  }
 }

--- a/src/test/resources/samples/enum/defGivingInvalidValue.def
+++ b/src/test/resources/samples/enum/defGivingInvalidValue.def
@@ -1,0 +1,8 @@
+enum MyEnum {
+  first
+  second
+}
+
+def lastMyEnum(): MyEnum => {
+  MyEnum.invalid
+}

--- a/src/test/resources/samples/enum/defGivingValue.def
+++ b/src/test/resources/samples/enum/defGivingValue.def
@@ -1,0 +1,8 @@
+enum MyEnum {
+  first
+  second
+}
+
+def lastMyEnum(): MyEnum => {
+  MyEnum.second
+}

--- a/src/test/resources/samples/enum/identity.def
+++ b/src/test/resources/samples/enum/identity.def
@@ -1,0 +1,8 @@
+enum MyEnum {
+  first
+  second
+}
+
+def identity(value: MyEnum): MyEnum => {
+  value
+}

--- a/src/test/resources/samples/nominal/enum.def
+++ b/src/test/resources/samples/nominal/enum.def
@@ -1,0 +1,4 @@
+enum MyEnum {
+  First
+  Second
+}

--- a/src/test/scala/definiti/core/end2end/EnumSpec.scala
+++ b/src/test/scala/definiti/core/end2end/EnumSpec.scala
@@ -1,0 +1,26 @@
+package definiti.core.end2end
+
+import definiti.core.ast.{Location, Root}
+import definiti.core.{Invalid, ValidationMatchers}
+
+class EnumSpec extends EndToEndSpec {
+  import ValidationMatchers._
+
+  "Project.generatePublicAST" should "validate the use in identity function" in {
+    val output = processFile("enum.identity")
+    output should be(valid)
+  }
+
+  it should "accept reading value directly from enum" in {
+    val output = processFile("enum.defGivingValue")
+    output should be(valid)
+  }
+
+  it should "refuse reading unknown value directly from enum" in {
+    val output = processFile("enum.defGivingInvalidValue")
+    output should beValidated[Root](Invalid(
+      message = "Unknown attribute MyEnum.invalid",
+      location = Location("src/test/resources/samples/enum/defGivingInvalidValue.def", 7, 3, 7, 17)
+    ))
+  }
+}

--- a/src/test/scala/definiti/core/end2end/NominalSpec.scala
+++ b/src/test/scala/definiti/core/end2end/NominalSpec.scala
@@ -19,6 +19,12 @@ class NominalSpec extends EndToEndSpec {
     output should beValidated[Root](expected)
   }
 
+  it should "generate a valid AST for a valid enum" in {
+    val expected = ValidValue(enum)
+    val output = processFile("nominal.enum")
+    output should beValidated[Root](expected)
+  }
+
   it should "generate a valid AST for a valid verification" in {
     val expected = ValidValue(verification)
     val output = processFile("nominal.verification")
@@ -75,6 +81,19 @@ object NominalSpec {
       inherited = Seq.empty,
       comment = None,
       location = Location(aliasTypeSrc, 1, 1, 1, 26)
+    ))
+  )
+
+  val enumSrc = "src/test/resources/samples/nominal/enum.def"
+  val enum: Root = Root(
+    elements = Seq(Enum(
+      name = "MyEnum",
+      cases = Seq(
+        EnumCase("First", None, Location(enumSrc, 2, 3, 2, 8)),
+        EnumCase("Second", None, Location(enumSrc, 3, 3, 3, 9))
+      ),
+      comment = None,
+      location = Location(enumSrc, 1, 1, 4, 2)
     ))
   )
 


### PR DESCRIPTION
In most languages, it is possible to define enumerations.
This commit implements them into Definiti.

An enumeration is simply a list of keywords.
However, these keywords are typed to gain more control in code.

This commit does the following:

* Define the syntax of enumerations
* Complete the AST for enumerations, an enumeration is defined as a class
* Process the new type in all the workflow (parsing, typing, linking, validation)
* Add JSON serialization
* Add an example file for manual tests
* Add specifications for new developments
* Remove unused keywords in antlr file (from externalisation of http into contexts)
* When creating library, the root package was ignored, correct it
* Correct `findTypeReference` which ignored classes