### PR TITLE
[#48] Accept verifications into alias type

### DIFF
--- a/src/main/antlr/Definiti.g4
+++ b/src/main/antlr/Definiti.g4
@@ -96,7 +96,11 @@ typeVerificationFunction: '(' IDENTIFIER ')' '=>' '{' chainedExpression '}';
 
 aliasType:
   DOC_COMMENT?
-  TYPE typeName=IDENTIFIER ('[' genericTypes=genericTypeList ']')? '=' referenceTypeName=IDENTIFIER ('[' aliasGenericTypes=genericTypeList ']')? verifyingList;
+  TYPE typeName=IDENTIFIER ('[' genericTypes=genericTypeList ']')? '=' referenceTypeName=IDENTIFIER ('[' aliasGenericTypes=genericTypeList ']')? verifyingList aliasTypeBody?;
+
+aliasTypeBody: '{'
+  typeVerification*
+'}';
 
 enumType:
   DOC_COMMENT?

--- a/src/main/resources/samples/src2/list.def
+++ b/src/main/resources/samples/src2/list.def
@@ -1,0 +1,10 @@
+package my.list
+
+type NonEmptyList[A] = List[A] {
+  verify {
+    "The list should not be empty"
+    (list) => {
+      list.nonEmpty()
+    }
+  }
+}

--- a/src/main/scala/definiti/core/ast/AST.scala
+++ b/src/main/scala/definiti/core/ast/AST.scala
@@ -41,6 +41,7 @@ case class AliasType(
   genericTypes: Seq[String],
   alias: TypeReference,
   inherited: Seq[VerificationReference],
+  verifications: Seq[TypeVerification],
   comment: Option[String],
   location: Location
 ) extends ClassDefinition

--- a/src/main/scala/definiti/core/ast/pure/AST.scala
+++ b/src/main/scala/definiti/core/ast/pure/AST.scala
@@ -46,13 +46,31 @@ private[core] sealed trait PureType extends PureClassDefinition {
   def comment: Option[String]
 }
 
-private[core] case class PureDefinedType(name: String, packageName: String, genericTypes: Seq[String], attributes: Seq[AttributeDefinition], verifications: Seq[PureTypeVerification], inherited: Seq[VerificationReference], comment: Option[String], location: Location) extends PureType {
+private[core] case class PureDefinedType(
+  name: String,
+  packageName: String,
+  genericTypes: Seq[String],
+  attributes: Seq[AttributeDefinition],
+  verifications: Seq[PureTypeVerification],
+  inherited: Seq[VerificationReference],
+  comment: Option[String],
+  location: Location
+) extends PureType {
   def methods: Seq[MethodDefinition] = Seq()
 
   override def canonicalName: String = ASTHelper.canonical(packageName, name)
 }
 
-private[core] case class PureAliasType(name: String, packageName: String, genericTypes: Seq[String], alias: TypeReference, inherited: Seq[VerificationReference], comment: Option[String], location: Location) extends PureType {
+private[core] case class PureAliasType(
+  name: String,
+  packageName: String,
+  genericTypes: Seq[String],
+  alias: TypeReference,
+  verifications: Seq[PureTypeVerification],
+  inherited: Seq[VerificationReference],
+  comment: Option[String],
+  location: Location
+) extends PureType {
   override def canonicalName: String = ASTHelper.canonical(packageName, name)
 }
 

--- a/src/main/scala/definiti/core/ast/typed/AST.scala
+++ b/src/main/scala/definiti/core/ast/typed/AST.scala
@@ -42,11 +42,29 @@ private[core] sealed trait Type extends TypedClassDefinition {
   def comment: Option[String]
 }
 
-private[core] case class TypedDefinedType(name: String, packageName: String, genericTypes: Seq[String], attributes: Seq[AttributeDefinition], verifications: Seq[TypeVerification], inherited: Seq[VerificationReference], comment: Option[String], location: Location) extends Type {
+private[core] case class TypedDefinedType(
+  name: String,
+  packageName: String,
+  genericTypes: Seq[String],
+  attributes: Seq[AttributeDefinition],
+  verifications: Seq[TypeVerification],
+  inherited: Seq[VerificationReference],
+  comment: Option[String],
+  location: Location
+) extends Type {
   override def canonicalName: String = ASTHelper.canonical(packageName, name)
 }
 
-private[core] case class TypedAliasType(name: String, packageName: String, genericTypes: Seq[String], alias: TypeReference, inherited: Seq[VerificationReference], comment: Option[String], location: Location) extends Type {
+private[core] case class TypedAliasType(
+  name: String,
+  packageName: String,
+  genericTypes: Seq[String],
+  alias: TypeReference,
+  verifications: Seq[TypeVerification],
+  inherited: Seq[VerificationReference],
+  comment: Option[String],
+  location: Location
+) extends Type {
   override def canonicalName: String = ASTHelper.canonical(packageName, name)
 }
 

--- a/src/main/scala/definiti/core/linking/ProjectLinking.scala
+++ b/src/main/scala/definiti/core/linking/ProjectLinking.scala
@@ -76,6 +76,7 @@ private[core] object ProjectLinking {
         aliasType.copy(
           packageName = packageName,
           alias = injectLinksIntoTypeReference(aliasType.alias, typeMapping),
+          verifications = aliasType.verifications.map(injectLinksIntoTypeVerification(_, typeMapping)),
           inherited = aliasType.inherited.map(injectLinksIntoVerificationReference(_, typeMapping))
         )
       case definedType: PureDefinedType =>

--- a/src/main/scala/definiti/core/plugin/serialization/PureRootJsonSerialization.scala
+++ b/src/main/scala/definiti/core/plugin/serialization/PureRootJsonSerialization.scala
@@ -30,7 +30,7 @@ trait PureRootJsonSerialization {
     Format("definedType", classOf[PureDefinedType])
   ))
   implicit lazy val pureDefinedTypeFormat: JsonFormat[PureDefinedType] = lazyFormat(jsonFormat8(PureDefinedType.apply))
-  implicit lazy val pureAliasTypeFormat: JsonFormat[PureAliasType] = lazyFormat(jsonFormat7(PureAliasType.apply))
+  implicit lazy val pureAliasTypeFormat: JsonFormat[PureAliasType] = lazyFormat(jsonFormat8(PureAliasType.apply))
   implicit lazy val pureTypeVerificationFormat: JsonFormat[PureTypeVerification] = lazyFormat(jsonFormat3(PureTypeVerification.apply))
   implicit lazy val pureEnumFormat: JsonFormat[PureEnum] = lazyFormat(jsonFormat5(PureEnum.apply))
   implicit lazy val pureEnumCaseFormat: JsonFormat[PureEnumCase] = lazyFormat(jsonFormat3(PureEnumCase.apply))

--- a/src/main/scala/definiti/core/plugin/serialization/RootJsonSerialization.scala
+++ b/src/main/scala/definiti/core/plugin/serialization/RootJsonSerialization.scala
@@ -33,7 +33,7 @@ trait RootJsonSerialization {
     Format("nativeClassDefinition", classOf[NativeClassDefinition])
   ))
   implicit lazy val definedTypeFormat: JsonFormat[DefinedType] = lazyFormat(jsonFormat7(DefinedType.apply))
-  implicit lazy val aliasTypeFormat: JsonFormat[AliasType] = lazyFormat(jsonFormat6(AliasType.apply))
+  implicit lazy val aliasTypeFormat: JsonFormat[AliasType] = lazyFormat(jsonFormat7(AliasType.apply))
   implicit lazy val nativeClassDefinitionFormat: JsonFormat[NativeClassDefinition] = lazyFormat(jsonFormat5(NativeClassDefinition.apply))
   implicit lazy val namedFunctionFormat: JsonFormat[NamedFunction] = lazyFormat(jsonFormat6(NamedFunction.apply))
 

--- a/src/main/scala/definiti/core/structure/ProjectStructure.scala
+++ b/src/main/scala/definiti/core/structure/ProjectStructure.scala
@@ -107,6 +107,7 @@ private[core] class ProjectStructure(root: typed.TypedRoot) {
       name = aliasType.name,
       genericTypes = aliasType.genericTypes,
       alias = aliasType.alias,
+      verifications = aliasType.verifications,
       inherited = aliasType.inherited,
       comment = aliasType.comment,
       location = aliasType.location

--- a/src/main/scala/definiti/core/typing/ClassDefinitionTyping.scala
+++ b/src/main/scala/definiti/core/typing/ClassDefinitionTyping.scala
@@ -10,7 +10,7 @@ private[core] class ClassDefinitionTyping(context: Context) {
     classDefinition match {
       case native: PureNativeClassDefinition => ValidValue(transformNativeClassDefinition(native))
       case definedType: PureDefinedType => addTypesIntoDefinedType(definedType)
-      case aliasType: PureAliasType => ValidValue(transformAliasType(aliasType))
+      case aliasType: PureAliasType => addTypesIntoAliasType(aliasType)
       case enum: PureEnum => ValidValue(transformEnum(enum))
     }
   }
@@ -53,16 +53,19 @@ private[core] class ClassDefinitionTyping(context: Context) {
     }
   }
 
-  def transformAliasType(aliasType: PureAliasType): TypedAliasType = {
-    TypedAliasType(
-      name = aliasType.name,
-      packageName = aliasType.packageName,
-      genericTypes = aliasType.genericTypes,
-      alias = aliasType.alias,
-      inherited = aliasType.inherited,
-      comment = aliasType.comment,
-      location = aliasType.location
-    )
+  def addTypesIntoAliasType(aliasType: PureAliasType): Validated[TypedAliasType] = {
+    Validated.squash(aliasType.verifications.map(addTypesIntoTypeVerification)).map { typeVerifications =>
+      TypedAliasType(
+        name = aliasType.name,
+        packageName = aliasType.packageName,
+        genericTypes = aliasType.genericTypes,
+        verifications = typeVerifications,
+        alias = aliasType.alias,
+        inherited = aliasType.inherited,
+        comment = aliasType.comment,
+        location = aliasType.location
+      )
+    }
   }
 
   def transformEnum(enum: PureEnum): TypedEnum = {

--- a/src/main/scala/definiti/core/validation/TypeValidation.scala
+++ b/src/main/scala/definiti/core/validation/TypeValidation.scala
@@ -7,9 +7,10 @@ private[core] trait TypeValidation {
   self: ASTValidation =>
 
   protected def validateAliasType(aliasType: AliasType): Validation = {
-    validateTypeReference(aliasType.alias, aliasType.genericTypes, aliasType.location).verifyingAlso {
-      Validation.join(aliasType.inherited.map(validateVerificationReference(_, aliasType.location)))
-    }
+    val aliasValidation = validateTypeReference(aliasType.alias, aliasType.genericTypes, aliasType.location)
+    val inheritedValidations = aliasType.inherited.map(validateVerificationReference(_, aliasType.location))
+    val verificationValidations = aliasType.verifications.map(validateTypeVerification)
+    Validation.join((aliasValidation +: inheritedValidations) ++ verificationValidations)
   }
 
   protected def validateDefinedType(definedType: DefinedType): Validation = {

--- a/src/test/resources/samples/aliasTypes/inline-verification.def
+++ b/src/test/resources/samples/aliasTypes/inline-verification.def
@@ -1,0 +1,8 @@
+type ListAlias[A] = List[A] {
+  verify {
+    "The list should not be empty"
+    (list) => {
+      list.nonEmpty()
+    }
+  }
+}

--- a/src/test/resources/samples/aliasTypes/invalid-inline-verification.def
+++ b/src/test/resources/samples/aliasTypes/invalid-inline-verification.def
@@ -1,0 +1,9 @@
+type RequiredString = String {
+  verify {
+    "The string should not be empty"
+    (string) => {
+      // missing parenthesis
+      string.nonEmpty
+    }
+  }
+}

--- a/src/test/scala/definiti/core/end2end/AliasTypeSpec.scala
+++ b/src/test/scala/definiti/core/end2end/AliasTypeSpec.scala
@@ -1,11 +1,64 @@
 package definiti.core.end2end
 
-import definiti.core.ValidationMatchers.valid
-import definiti.core.ast.Root
+import definiti.core.ValidValue
+import definiti.core.ValidationMatchers._
+import definiti.core.ast._
 
 class AliasTypeSpec extends EndToEndSpec {
+  import AliasTypeSpec._
+
   "Project.generatePublicAST" should "generate the AST with an alias containing generics" in {
     val output = processFile("aliasTypes.ListAlias")
     output shouldBe valid[Root]
   }
+
+  it should "generate the AST with an inline verification" in {
+    val expected = ValidValue(inlineVerification)
+    val output = processFile("aliasTypes.inline-verification")
+    output should beValidated[Root](expected)
+  }
+
+  it should "invalid the AST when the inline verification is invalid" in {
+    val output = processFile("aliasTypes.invalid-inline-verification")
+    output shouldBe invalid
+  }
+}
+
+object AliasTypeSpec {
+  val inlineVerificationFile = "src/test/resources/samples/aliasTypes/inline-verification.def"
+  val inlineVerification = Root(Seq(
+    AliasType(
+      name = "ListAlias",
+      genericTypes = Seq("A"),
+      alias = TypeReference("List", Seq(TypeReference("A"))),
+      inherited = Seq.empty,
+      verifications = Seq(TypeVerification(
+        message = "The list should not be empty",
+        function = DefinedFunction(
+          parameters = Seq(ParameterDefinition(
+            name = "list",
+            typeReference = TypeReference("ListAlias", Seq(TypeReference("A"))),
+            location = Location(inlineVerificationFile, 4, 6, 4, 10)
+          )),
+          body = MethodCall(
+            expression = Reference(
+              name = "list",
+              returnType = TypeReference("ListAlias", Seq(TypeReference("A"))),
+              location = Location(inlineVerificationFile, 5, 7, 5, 11)
+            ),
+            method = "nonEmpty",
+            parameters = Seq.empty,
+            generics = Seq.empty,
+            returnType = TypeReference("Boolean"),
+            location = Location(inlineVerificationFile, 5, 7, 5, 22)
+          ),
+          genericTypes = Seq.empty,
+          location = Location(inlineVerificationFile, 4, 5, 6, 6)
+        ),
+        location = Location(inlineVerificationFile, 2, 3, 7, 4)
+      )),
+      comment = None,
+      location = Location(inlineVerificationFile, 1, 1, 8, 2)
+    )
+  ))
 }

--- a/src/test/scala/definiti/core/end2end/NamespaceSpec.scala
+++ b/src/test/scala/definiti/core/end2end/NamespaceSpec.scala
@@ -34,6 +34,7 @@ object NamespaceSpec {
             name = "AliasString",
             genericTypes = Seq.empty,
             alias = TypeReference("String"),
+            verifications = Seq.empty,
             inherited = Seq.empty,
             comment = None,
             location = Location(validSubnamespaceSrc, 3, 1, 3, 26)
@@ -60,6 +61,7 @@ object NamespaceSpec {
                 name = "AliasString",
                 genericTypes = Seq.empty,
                 alias = TypeReference("String"),
+                verifications = Seq.empty,
                 inherited = Seq.empty,
                 comment = None,
                 location = Location(validSub2namespaceSrc, 3, 1, 3, 26)

--- a/src/test/scala/definiti/core/end2end/NominalSpec.scala
+++ b/src/test/scala/definiti/core/end2end/NominalSpec.scala
@@ -78,6 +78,7 @@ object NominalSpec {
       name = "AliasString",
       genericTypes = Seq.empty,
       alias = TypeReference("String"),
+      verifications = Seq.empty,
       inherited = Seq.empty,
       comment = None,
       location = Location(aliasTypeSrc, 1, 1, 1, 26)
@@ -147,6 +148,7 @@ object NominalSpec {
         name = "AliasString",
         genericTypes = Seq.empty,
         alias = TypeReference("String"),
+        verifications = Seq.empty,
         inherited = Seq.empty,
         comment = None,
         location = Location(packageAliasTypeSrc, 3, 1, 3, 26)

--- a/src/test/scala/definiti/core/generators/TypeGenerator.scala
+++ b/src/test/scala/definiti/core/generators/TypeGenerator.scala
@@ -35,6 +35,7 @@ object TypeGenerator {
     packageName <- ASTGenerator.anyPackageName
     genericTypes <- ASTGenerator.listOfGenericTypeDefinition
     alias <- ASTGenerator.referencedTypeReference
+    verifications <- Gen.listOf(anyTypeVerification)
     inherited <- Gen.listOf(VerificationGenerator.anyVerificationReference)
     comment <- Gen.option(ASTGenerator.anyString)
     location <- ASTGenerator.anyLocation
@@ -44,6 +45,7 @@ object TypeGenerator {
       packageName,
       genericTypes,
       alias,
+      verifications,
       inherited,
       comment,
       location

--- a/src/test/scala/definiti/core/parser/project/ProcessTypeVerificationSpec.scala
+++ b/src/test/scala/definiti/core/parser/project/ProcessTypeVerificationSpec.scala
@@ -18,7 +18,7 @@ class ProcessTypeVerificationSpec extends FlatSpec with Matchers with PropertyCh
     } yield (typeVerificationContext, typeName)
 
     forAll(cases) { case (typeVerificationContext, typeName) =>
-      val result = definitiASTParser.processTypeVerification(typeVerificationContext, typeName)
+      val result = definitiASTParser.processTypeVerification(typeVerificationContext, typeName, Seq.empty)
       result.function.parameters should have length 1
       result.function.parameters.head.typeReference should be (a[TypeReference])
       result.function.parameters.head.typeReference.asInstanceOf[TypeReference].typeName should be (typeName)


### PR DESCRIPTION
When we want to declare an alias type and set verification on it,
we have to declare the verification outside.

It is relevant to split types and verifications,
but sometimes, there is no value to split it.

This commit does the following:

* Accept a simple body in alias type (verifications only)
* Alias types in AST have verifications like defined type
* Correct type of verification parameter, it did not consider generics
* Add tests to validate new feature
* Create a sample to test it manually

This PR resolves #48.