### PR TITLE
[#41] Add verification system with external parameters

### DIFF
--- a/src/main/antlr/Definiti.g4
+++ b/src/main/antlr/Definiti.g4
@@ -107,8 +107,19 @@ attributeDefinition:
   DOC_COMMENT?
   attributeName=IDENTIFIER ':' typeDeclaration verifyingList;
 
-typeVerification:
+typeVerification
+  : atomicTypeVerification
+  | dependentTypeVerification
+  ;
+
+atomicTypeVerification:
   VERIFY '{'
+    verificationMessage
+    typeVerificationFunction
+  '}';
+
+dependentTypeVerification:
+  VERIFY verificationName=IDENTIFIER '(' parameterListDefinition ')' '{'
     verificationMessage
     typeVerificationFunction
   '}';

--- a/src/main/scala/definiti/core/ast/AST.scala
+++ b/src/main/scala/definiti/core/ast/AST.scala
@@ -193,7 +193,24 @@ case class VerificationReference(
   location: Location
 )
 
-case class TypeVerification(message: VerificationMessage, function: DefinedFunction, location: Location)
+sealed trait TypeVerification {
+  def message: VerificationMessage
+  def function: DefinedFunction
+  def location: Location
+}
+
+case class AtomicTypeVerification(
+  message: VerificationMessage,
+  function: DefinedFunction,
+  location: Location
+) extends TypeVerification
+
+case class DependentTypeVerification(
+  name: String,
+  message: VerificationMessage,
+  function: DefinedFunction,
+  location: Location
+) extends TypeVerification
 
 case class DefinedFunction(parameters: Seq[ParameterDefinition], body: Expression, genericTypes: Seq[String], location: Location)
 

--- a/src/main/scala/definiti/core/ast/pure/AST.scala
+++ b/src/main/scala/definiti/core/ast/pure/AST.scala
@@ -121,7 +121,20 @@ private[core] case class PureEnumCase(
   location: Location
 )
 
-private[core] case class PureTypeVerification(message: VerificationMessage, function: PureDefinedFunction, location: Location)
+private[core] sealed trait PureTypeVerification
+
+private[core] case class PureAtomicTypeVerification(
+  message: VerificationMessage,
+  function: PureDefinedFunction,
+  location: Location
+) extends PureTypeVerification
+
+private[core] case class PureDependentTypeVerification(
+  name: String,
+  message: VerificationMessage,
+  function: PureDefinedFunction,
+  location: Location
+) extends PureTypeVerification
 
 private[core] case class PureNamedFunction(
   name: String,

--- a/src/main/scala/definiti/core/linking/ProjectLinking.scala
+++ b/src/main/scala/definiti/core/linking/ProjectLinking.scala
@@ -108,10 +108,18 @@ private[core] object ProjectLinking {
   }
 
   def injectLinksIntoTypeVerification(typeVerification: PureTypeVerification, typeMapping: TypeMapping): PureTypeVerification = {
-    typeVerification.copy(
-      message = injectLinksIntoVerificationMessage(typeVerification.message, typeMapping),
-      function = injectLinksIntoFunction(typeVerification.function, typeMapping)
-    )
+    typeVerification match {
+      case atomicTypeVerification: PureAtomicTypeVerification =>
+        atomicTypeVerification.copy(
+          message = injectLinksIntoVerificationMessage(atomicTypeVerification.message, typeMapping),
+          function = injectLinksIntoFunction(atomicTypeVerification.function, typeMapping)
+        )
+      case dependentTypeVerification: PureDependentTypeVerification =>
+        dependentTypeVerification.copy(
+          message = injectLinksIntoVerificationMessage(dependentTypeVerification.message, typeMapping),
+          function = injectLinksIntoFunction(dependentTypeVerification.function, typeMapping)
+        )
+    }
   }
 
   def injectLinksIntoNamedFunction(namedFunction: PureNamedFunction, packageName: String, typeMapping: TypeMapping): PureNamedFunction = {

--- a/src/main/scala/definiti/core/plugin/serialization/PureRootJsonSerialization.scala
+++ b/src/main/scala/definiti/core/plugin/serialization/PureRootJsonSerialization.scala
@@ -33,7 +33,12 @@ trait PureRootJsonSerialization {
   implicit lazy val pureAttributeDefinitionFormat: JsonFormat[PureAttributeDefinition] = lazyFormat(jsonFormat5(PureAttributeDefinition.apply))
   implicit lazy val pureTypeDeclarationFormat: JsonFormat[PureTypeDeclaration] = lazyFormat(jsonFormat4(PureTypeDeclaration.apply))
   implicit lazy val pureAliasTypeFormat: JsonFormat[PureAliasType] = lazyFormat(jsonFormat9(PureAliasType.apply))
-  implicit lazy val pureTypeVerificationFormat: JsonFormat[PureTypeVerification] = lazyFormat(jsonFormat3(PureTypeVerification.apply))
+  implicit lazy val pureTypeVerificationFormat: JsonFormat[PureTypeVerification] = lazyFormat(sealedTraitFormat[PureTypeVerification](
+    Format("atomic", classOf[PureAtomicTypeVerification]),
+    Format("dependent", classOf[PureDependentTypeVerification])
+  ))
+  implicit lazy val pureAtomicTypeVerificationFormat: JsonFormat[PureAtomicTypeVerification] = lazyFormat(jsonFormat3(PureAtomicTypeVerification.apply))
+  implicit lazy val pureDependentTypeVerificationFormat: JsonFormat[PureDependentTypeVerification] = lazyFormat(jsonFormat4(PureDependentTypeVerification.apply))
   implicit lazy val pureEnumFormat: JsonFormat[PureEnum] = lazyFormat(jsonFormat5(PureEnum.apply))
   implicit lazy val pureEnumCaseFormat: JsonFormat[PureEnumCase] = lazyFormat(jsonFormat3(PureEnumCase.apply))
   implicit lazy val pureNamedFunctionFormat: JsonFormat[PureNamedFunction] = lazyFormat(jsonFormat7(PureNamedFunction.apply))

--- a/src/main/scala/definiti/core/plugin/serialization/RootJsonSerialization.scala
+++ b/src/main/scala/definiti/core/plugin/serialization/RootJsonSerialization.scala
@@ -56,7 +56,12 @@ trait RootJsonSerialization {
   implicit lazy val parameterDefinitionFormat: JsonFormat[ParameterDefinition] = lazyFormat(jsonFormat3(ParameterDefinition.apply))
   implicit lazy val methodDefinitionFormat: JsonFormat[MethodDefinition] = lazyFormat(jsonFormat5(MethodDefinition.apply))
   implicit lazy val verificationReferenceFormat: JsonFormat[VerificationReference] = lazyFormat(jsonFormat3(VerificationReference.apply))
-  implicit lazy val typeVerificationFormat: JsonFormat[TypeVerification] = lazyFormat(jsonFormat3(TypeVerification.apply))
+  implicit lazy val typeVerificationFormat: JsonFormat[TypeVerification] = lazyFormat(sealedTraitFormat[TypeVerification](
+    Format("atomic", classOf[AtomicTypeVerification]),
+    Format("dependent", classOf[DependentTypeVerification])
+  ))
+  implicit lazy val atomicTypeVerificationFormat: JsonFormat[AtomicTypeVerification] = lazyFormat(jsonFormat3(AtomicTypeVerification.apply))
+  implicit lazy val dependentTypeVerificationFormat: JsonFormat[DependentTypeVerification] = lazyFormat(jsonFormat4(DependentTypeVerification.apply))
   implicit lazy val definedFunctionFormat: JsonFormat[DefinedFunction] = lazyFormat(jsonFormat4(DefinedFunction.apply))
   implicit lazy val parameterFormat: JsonFormat[Parameter] = lazyFormat(jsonFormat3(Parameter.apply))
 

--- a/src/main/scala/definiti/core/typing/ClassDefinitionTyping.scala
+++ b/src/main/scala/definiti/core/typing/ClassDefinitionTyping.scala
@@ -90,14 +90,29 @@ private[core] class ClassDefinitionTyping(context: Context) {
   }
 
   def addTypesIntoTypeVerification(typeVerification: PureTypeVerification): Validated[TypeVerification] = {
-    val functionContext = DefinedFunctionContext(context, typeVerification.function)
-    val validatedFunction = new FunctionTyping(functionContext).addTypesIntoDefinedFunction(typeVerification.function)
-    validatedFunction.map { function =>
-      TypeVerification(
-        message = typeVerification.message,
-        function = function,
-        location = typeVerification.location
-      )
+    typeVerification match {
+      case atomicTypeVerification: PureAtomicTypeVerification =>
+        val functionContext = DefinedFunctionContext(context, atomicTypeVerification.function)
+        val validatedFunction = new FunctionTyping(functionContext).addTypesIntoDefinedFunction(atomicTypeVerification.function)
+        validatedFunction.map { function =>
+          AtomicTypeVerification(
+            message = atomicTypeVerification.message,
+            function = function,
+            location = atomicTypeVerification.location
+          )
+        }
+
+      case dependentTypeVerification: PureDependentTypeVerification =>
+        val functionContext = DefinedFunctionContext(context, dependentTypeVerification.function)
+        val validatedFunction = new FunctionTyping(functionContext).addTypesIntoDefinedFunction(dependentTypeVerification.function)
+        validatedFunction.map { function =>
+          DependentTypeVerification(
+            name = dependentTypeVerification.name,
+            message = dependentTypeVerification.message,
+            function = function,
+            location = dependentTypeVerification.location
+          )
+        }
     }
   }
 

--- a/src/main/scala/definiti/core/validation/Controls.scala
+++ b/src/main/scala/definiti/core/validation/Controls.scala
@@ -39,6 +39,7 @@ object Controls {
     TypeDeclarationParametersControl,
     TypeVerificationIsBooleanControl,
     TypeVerificationIsOkKoControl,
+    TypeVerificationParameterUsableControl,
     VerificationIsBooleanControl,
     VerificationIsOkKoControl,
     VerificationNameUniquenessControl,

--- a/src/main/scala/definiti/core/validation/controls/AliasTypeTypeControl.scala
+++ b/src/main/scala/definiti/core/validation/controls/AliasTypeTypeControl.scala
@@ -17,7 +17,6 @@ object AliasTypeTypeControl extends Control with TypeReferenceControlHelper {
   private def controlAliasType(aliasType: AliasType, library: Library): ControlResult = {
     controlTypeReference(
       typeReference = aliasType.alias,
-      elementName = aliasType.fullName,
       availableGenerics = aliasType.genericTypes,
       location = aliasType.location,
       library = library

--- a/src/main/scala/definiti/core/validation/controls/AttributeTypeControl.scala
+++ b/src/main/scala/definiti/core/validation/controls/AttributeTypeControl.scala
@@ -23,7 +23,6 @@ object AttributeTypeControl extends Control with TypeReferenceControlHelper {
   private def controlAttribute(attributeDefinition: AttributeDefinition, definedType: DefinedType, library: Library): ControlResult = {
     controlTypeReference(
       typeReference = attributeDefinition.typeDeclaration,
-      elementName = s"${definedType.fullName}.${attributeDefinition.name}",
       availableGenerics = definedType.genericTypes,
       location = attributeDefinition.location,
       library = library

--- a/src/main/scala/definiti/core/validation/controls/NamedFunctionTypeControl.scala
+++ b/src/main/scala/definiti/core/validation/controls/NamedFunctionTypeControl.scala
@@ -22,7 +22,6 @@ object NamedFunctionTypeControl extends Control with TypeReferenceControlHelper 
   private def controlReturnTypeReference(namedFunction: NamedFunction, library: Library): ControlResult = {
     controlTypeReference(
       typeReference = namedFunction.returnType,
-      elementName = namedFunction.fullName,
       availableGenerics = namedFunction.genericTypes,
       location = namedFunction.location,
       library = library

--- a/src/main/scala/definiti/core/validation/controls/TypeVerificationParameterUsableControl.scala
+++ b/src/main/scala/definiti/core/validation/controls/TypeVerificationParameterUsableControl.scala
@@ -1,0 +1,71 @@
+package definiti.core.validation.controls
+
+import definiti.core.Alert
+import definiti.core.ast._
+import definiti.core.validation.helpers.TypeReferenceControlHelper
+import definiti.core.validation.{Control, ControlLevel, ControlResult}
+
+object TypeVerificationParameterUsableControl extends Control with TypeReferenceControlHelper {
+  override val description: String = "Check if parameters in type verifications are valid"
+
+  override val defaultLevel: ControlLevel.Value = ControlLevel.error
+
+  override def control(root: Root, library: Library): ControlResult = {
+    ControlResult.squash {
+      extractParameters(library).map(controlParameter(_, library))
+    }
+  }
+
+  private def extractParameters(library: Library): Seq[ParameterInfo] = {
+    val aliasTypeParameters = library.aliasTypes.flatMap(extractParametersFromAliasType)
+    val definedTypeParameters = library.definedTypes.flatMap(extractParametersFromDefinedType)
+    val namedFunctionTypeParameters = library.namedFunctions.flatMap(extractParametersFromNamedFunction)
+    val verificationTypeParameters = library.verifications.flatMap(extractParametersFromVerification)
+    aliasTypeParameters ++ definedTypeParameters ++ namedFunctionTypeParameters ++ verificationTypeParameters
+  }
+
+  private def extractParametersFromAliasType(aliasType: AliasType): Seq[ParameterInfo] = {
+    val typeParameters = aliasType.parameters
+      .map(ParameterInfo(_, aliasType.genericTypes))
+    val verificationParameters = aliasType.verifications
+      .flatMap(_.function.parameters)
+      .map(ParameterInfo(_, aliasType.genericTypes))
+
+    typeParameters ++ verificationParameters
+  }
+
+  private def extractParametersFromDefinedType(definedType: DefinedType): Seq[ParameterInfo] = {
+    val typeParameters = definedType.parameters
+      .map(ParameterInfo(_, definedType.genericTypes))
+    val verificationParameters = definedType.verifications
+      .flatMap(_.function.parameters)
+      .map(ParameterInfo(_, definedType.genericTypes))
+
+    typeParameters ++ verificationParameters
+  }
+
+  private def extractParametersFromNamedFunction(namedFunction: NamedFunction): Seq[ParameterInfo] = {
+    namedFunction.parameters.map(ParameterInfo(_, namedFunction.genericTypes))
+  }
+
+  private def extractParametersFromVerification(verification: Verification): Seq[ParameterInfo] = {
+    val verificationParameters = verification.parameters.map(ParameterInfo(_, Seq.empty))
+    val functionParameters = verification.function.parameters.map(ParameterInfo(_, verification.function.genericTypes))
+    verificationParameters ++ functionParameters
+  }
+
+  private def controlParameter(parameterInfo: ParameterInfo, library: Library): ControlResult = {
+    parameterInfo.parameter.typeReference match {
+      case typeReference: TypeReference =>
+        controlTypeReference(typeReference, parameterInfo.generics, parameterInfo.parameter.location, library)
+      case _ =>
+        unexpectedTypeError(parameterInfo.parameter.typeReference, parameterInfo.parameter.location)
+    }
+  }
+
+  def unexpectedTypeError(typeReference: AbstractTypeReference, location: Location): Alert = {
+    alert(s"Unexpected type: ${typeReference.readableString}", location)
+  }
+
+  case class ParameterInfo(parameter: ParameterDefinition, generics: Seq[String])
+}

--- a/src/main/scala/definiti/core/validation/controls/VerificationTypeControl.scala
+++ b/src/main/scala/definiti/core/validation/controls/VerificationTypeControl.scala
@@ -32,7 +32,6 @@ object VerificationTypeControl extends Control with TypeReferenceControlHelper {
   private def controlTypeReference(typeReference: TypeReference, verification: Verification, location: Location, library: Library): ControlResult = {
     controlTypeReference(
       typeReference = typeReference,
-      elementName = verification.fullName,
       availableGenerics = verification.function.genericTypes,
       location = location,
       library = library

--- a/src/main/scala/definiti/core/validation/helpers/TypeReferenceControlHelper.scala
+++ b/src/main/scala/definiti/core/validation/helpers/TypeReferenceControlHelper.scala
@@ -7,7 +7,7 @@ import definiti.core.validation.{Control, ControlResult}
 trait TypeReferenceControlHelper {
   self: Control =>
 
-  def controlTypeReference(typeReference: TypeReference, elementName: String, availableGenerics: Seq[String], location: Location, library: Library): ControlResult = {
+  def controlTypeReference(typeReference: TypeReference, availableGenerics: Seq[String], location: Location, library: Library): ControlResult = {
     def process(typeReference: TypeReference): Seq[Alert] = {
       val typeNameAlerts = controlTypeName(typeReference.typeName)
       val genericAlerts = typeReference.genericTypes.flatMap(process)
@@ -20,16 +20,16 @@ trait TypeReferenceControlHelper {
       } else if (availableGenerics.contains(typeName)) {
         Seq.empty
       } else {
-        Seq(errorUnknownType(typeName, elementName, location))
+        Seq(errorUnknownType(typeName, location))
       }
     }
 
     ControlResult(process(typeReference))
   }
 
-  def errorUnknownType(typeName: String, elementName: String, location: Location): Alert = {
+  def errorUnknownType(typeName: String, location: Location): Alert = {
     alert(
-      s"Unknown type ${typeName} found in ${elementName}",
+      s"Unknown type ${typeName}",
       location
     )
   }

--- a/src/test/resources/samples/controls/typeVerificationIsBoolean/dependentType.def
+++ b/src/test/resources/samples/controls/typeVerificationIsBoolean/dependentType.def
@@ -1,0 +1,20 @@
+type Range {
+  start: Number
+  end: Number
+
+  verify universe(minimal: Number) {
+    "Should be after"
+    (range) => {
+      range.start > minimal
+    }
+  }
+}
+
+type OtherRange = Range {
+  verify universe(maximal: Number) {
+    "Should be before"
+    (range) => {
+      range.end < maximal
+    }
+  }
+}

--- a/src/test/resources/samples/controls/typeVerificationIsOkKo/dependentType.def
+++ b/src/test/resources/samples/controls/typeVerificationIsOkKo/dependentType.def
@@ -1,0 +1,28 @@
+type Range {
+  start: Number
+  end: Number
+
+  verify universe(minimal: Number) {
+    message("range.after", Number)
+    (range) => {
+      if (range.start > minimal) {
+        ok
+      } else {
+        ko(minimal)
+      }
+    }
+  }
+}
+
+type OtherRange = Range {
+  verify universe(maximal: Number) {
+    message("range.before")
+    (range) => {
+      if (range.start < maximal) {
+        ok
+      } else {
+        ko(maximal)
+      }
+    }
+  }
+}

--- a/src/test/resources/samples/controls/typeVerificationParameterUsable/invalidParameterType.def
+++ b/src/test/resources/samples/controls/typeVerificationParameterUsable/invalidParameterType.def
@@ -1,0 +1,19 @@
+type Contact {
+  phones: List[String]
+
+  verify withConfiguration(minimalNumberOfPhones: UnknownNumber) {
+    "contact.minimal.number.of.phones"
+    (user) => {
+      user.phones.size >= minimalNumberOfPhones
+    }
+  }
+}
+
+type ContactWithMaximalNumberOfPhones = Contact {
+  verify withConfiguration(maximalNumberOfPhones: UnknownNumber) {
+    "contact.minimal.number.of.phones"
+    (user) => {
+      user.phones.size <= maximalNumberOfPhones
+    }
+  }
+}

--- a/src/test/resources/samples/controls/typeVerificationParameterUsable/nominal.def
+++ b/src/test/resources/samples/controls/typeVerificationParameterUsable/nominal.def
@@ -1,0 +1,19 @@
+type Contact {
+  phones: List[String]
+  
+  verify withConfiguration(minimalNumberOfPhones: Number) {
+    "contact.minimal.number.of.phones"
+    (user) => {
+      user.phones.size >= minimalNumberOfPhones
+    }
+  }
+}
+
+type ContactWithMaximalNumberOfPhones = Contact {
+  verify withConfiguration(maximalNumberOfPhones: Number) {
+    "contact.minimal.number.of.phones"
+    (user) => {
+      user.phones.size <= maximalNumberOfPhones
+    }
+  }
+}

--- a/src/test/resources/samples/controls/typeVerificationParameterUsable/package.def
+++ b/src/test/resources/samples/controls/typeVerificationParameterUsable/package.def
@@ -1,0 +1,21 @@
+package my.test
+
+type Contact {
+  phones: List[String]
+
+  verify withConfiguration(minimalNumberOfPhones: Number) {
+    "contact.minimal.number.of.phones"
+    (user) => {
+      user.phones.size >= minimalNumberOfPhones
+    }
+  }
+}
+
+type ContactWithMaximalNumberOfPhones = Contact {
+  verify withConfiguration(maximalNumberOfPhones: Number) {
+    "contact.minimal.number.of.phones"
+    (user) => {
+      user.phones.size <= maximalNumberOfPhones
+    }
+  }
+}

--- a/src/test/scala/definiti/core/end2end/AliasTypeSpec.scala
+++ b/src/test/scala/definiti/core/end2end/AliasTypeSpec.scala
@@ -39,7 +39,7 @@ object AliasTypeSpec {
         location = Location(inlineVerificationFile, 1, 21, 1, 28)
       ),
       inherited = Seq.empty,
-      verifications = Seq(TypeVerification(
+      verifications = Seq(AtomicTypeVerification(
         message = LiteralMessage("The list should not be empty", Location(inlineVerificationFile, 3, 5, 3, 35)),
         function = DefinedFunction(
           parameters = Seq(ParameterDefinition(

--- a/src/test/scala/definiti/core/end2end/GeneratePublicApiSpec.scala
+++ b/src/test/scala/definiti/core/end2end/GeneratePublicApiSpec.scala
@@ -70,7 +70,7 @@ object GeneratePublicApiSpec {
             )
           ),
           verifications = Seq(
-            TypeVerification(
+            AtomicTypeVerification(
               message = LiteralMessage("No tag can be empty", Location(validBlogSrcTypes, 12, 5, 12, 26)),
               function = DefinedFunction(
                 parameters = Seq(ParameterDefinition("blog", TypeReference("blog.Blog"), Location(validBlogSrcTypes, 13, 6, 13, 10))),

--- a/src/test/scala/definiti/core/end2end/controls/AliasTypeTypeControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/AliasTypeTypeControlSpec.scala
@@ -27,7 +27,7 @@ class AliasTypeTypeControlSpec extends EndToEndSpec {
   it should "invalidate an alias type with an unknown type" in {
     val output = processFile("controls.aliasTypeType.unknownType", configuration)
     output should beResult(Ko[Root](
-      AliasTypeTypeControl.errorUnknownType("Unknown", "AliasUnknown", unknownTypeLocation(1, 1, 28))
+      AliasTypeTypeControl.errorUnknownType("Unknown", unknownTypeLocation(1, 1, 28))
     ))
   }
 }

--- a/src/test/scala/definiti/core/end2end/controls/AttributeTypeControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/AttributeTypeControlSpec.scala
@@ -27,7 +27,7 @@ class AttributeTypeControlSpec extends EndToEndSpec {
   it should "invalidate an attribute with an unknown type" in {
     val output = processFile("controls.attributeType.unknownType", configuration)
     output should beResult(Ko[Root](
-      AttributeTypeControl.errorUnknownType("Unknown", "MyType.myAttribute", unknownTypeLocation(2, 3, 23))
+      AttributeTypeControl.errorUnknownType("Unknown", unknownTypeLocation(2, 3, 23))
     ))
   }
 }

--- a/src/test/scala/definiti/core/end2end/controls/NamedFunctionTypeControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/NamedFunctionTypeControlSpec.scala
@@ -41,7 +41,7 @@ class NamedFunctionTypeControlSpec extends EndToEndSpec {
     val output = processFile("controls.namedFunctionType.invalidGenerics", configuration)
     output should beKo(
       NamedFunctionTypeControl.errorDifferentType("myFunction", "List[B]", "List[A]", invalidGenericsLocation(1, 1, 3, 2)),
-      NamedFunctionTypeControl.errorUnknownType("B", "myFunction", invalidGenericsLocation(1, 1, 3, 2))
+      NamedFunctionTypeControl.errorUnknownType("B", invalidGenericsLocation(1, 1, 3, 2))
     )
   }
 
@@ -49,7 +49,7 @@ class NamedFunctionTypeControlSpec extends EndToEndSpec {
     val output = processFile("controls.namedFunctionType.unknownType", configuration)
     output should beKo(
       NamedFunctionTypeControl.errorDifferentType("myFunction", "Unknown", "String", invalidUnknownLocation(1, 1, 3, 2)),
-      NamedFunctionTypeControl.errorUnknownType("Unknown", "myFunction", invalidUnknownLocation(1, 1, 3, 2))
+      NamedFunctionTypeControl.errorUnknownType("Unknown", invalidUnknownLocation(1, 1, 3, 2))
     )
   }
 }

--- a/src/test/scala/definiti/core/end2end/controls/TypeVerificationIsBooleanControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/TypeVerificationIsBooleanControlSpec.scala
@@ -9,8 +9,13 @@ import definiti.core.validation.controls.TypeVerificationIsBooleanControl
 class TypeVerificationIsBooleanControlSpec extends EndToEndSpec {
   import TypeVerificationIsBooleanControlSpec._
 
-  "Project.generatePublicAST" should "validate a type verification returning boolean" in {
+  "Project.generatePublicAST" should "validate an atomic type verification returning boolean" in {
     val output = processFile("controls.typeVerificationIsBoolean.nominal", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "validate a dependent type verification returning boolean" in {
+    val output = processFile("controls.typeVerificationIsBoolean.dependentType", configuration)
     output shouldBe ok[Root]
   }
 

--- a/src/test/scala/definiti/core/end2end/controls/TypeVerificationParameterUsableControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/TypeVerificationParameterUsableControlSpec.scala
@@ -1,0 +1,36 @@
+package definiti.core.end2end.controls
+
+import definiti.core.ProgramResultMatchers._
+import definiti.core.ast.Root
+import definiti.core.end2end.EndToEndSpec
+import definiti.core.validation.controls.TypeVerificationParameterUsableControl
+
+class TypeVerificationParameterUsableControlSpec extends EndToEndSpec {
+  import TypeVerificationParameterUsableControlSpec._
+
+  "Project.generatePublicAST" should "validate a type verification with valid parameters" in {
+    val output = processFile("controls.typeVerificationParameterUsable.nominal", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "validate a type verification with valid parameters in a package" in {
+    val output = processFile("controls.typeVerificationParameterUsable.package", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "invalidate a type verification with invalid parameters" in {
+    val output = processFile("controls.typeVerificationParameterUsable.invalidParameterType", configuration)
+    output should beKo(
+      TypeVerificationParameterUsableControl.errorUnknownType("UnknownNumber", invalidParameterLocation(4, 28, 64)),
+      TypeVerificationParameterUsableControl.errorUnknownType("UnknownNumber", invalidParameterLocation(13, 28, 64))
+    )
+  }
+}
+
+object TypeVerificationParameterUsableControlSpec {
+  import EndToEndSpec._
+
+  val configuration = configurationForceControls(TypeVerificationParameterUsableControl.name)
+
+  val invalidParameterLocation = LocationPath.control(TypeVerificationParameterUsableControl.name, "invalidParameterType")
+}

--- a/src/test/scala/definiti/core/end2end/controls/VerificationTypeControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/VerificationTypeControlSpec.scala
@@ -28,7 +28,7 @@ class VerificationTypeControlSpec extends EndToEndSpec {
   it should "invalidate a verification with an unknown type" in {
     val output = processFile("controls.verificationType.unknownType", configuration)
     output should beResult(Ko[Root](
-      VerificationTypeControl.errorUnknownType("Unknown", "UnknownVerification", unknownTypeLocation(3, 4, 20))
+      VerificationTypeControl.errorUnknownType("Unknown", unknownTypeLocation(3, 4, 20))
     ))
   }
 }


### PR DESCRIPTION
Usually, we need to control data of our application with external parameters.
And these parameters can come from side effect functions (ex: `Date.now`)
or from configuration directly.

So we add parameters to type verifications.

This commit does the following:

* Introduce syntax for parameters of type verifications
* Update the AST to accept parameters on type verifications
* Consider this new AST element through the process
* Add control to test if these parameters have a valid type
* Simplify `TypeReferenceControlHelper.errorUnknownType` because location is useful enough to give the context
* Add tests verifying this new feature
* Update tests to accept new AST structure

This pull request resolves #41.