### PR TITLE
[#56] Trigger validation for extended context on root namespace

### DIFF
--- a/src/main/scala/definiti/core/validation/ASTValidation.scala
+++ b/src/main/scala/definiti/core/validation/ASTValidation.scala
@@ -16,7 +16,7 @@ private[core] class ASTValidation(configuration: Configuration, library: Library
 
   private def validateExtendedContexts(): Validated[NoResult] = {
     Validated.squash {
-      library.namespaces.flatMap(_.elements).collect {
+      (library.root.elements ++ library.namespaces.flatMap(_.elements)).collect {
         case extendedContext: ExtendedContext[_] => validateExtendedContext(extendedContext, library)
       }
     }.map(_ => NoResult)

--- a/src/test/resources/samples/extendedContext/namespace.def
+++ b/src/test/resources/samples/extendedContext/namespace.def
@@ -1,0 +1,5 @@
+package x
+
+context stringContext {{{
+  Content!
+}}}

--- a/src/test/resources/samples/extendedContext/nominal.def
+++ b/src/test/resources/samples/extendedContext/nominal.def
@@ -1,0 +1,3 @@
+context stringContext {{{
+  Content!
+}}}

--- a/src/test/scala/definiti/core/end2end/ExtendedContextSpec.scala
+++ b/src/test/scala/definiti/core/end2end/ExtendedContextSpec.scala
@@ -1,0 +1,51 @@
+package definiti.core.end2end
+
+import definiti.core.ProgramResult.NoResult
+import definiti.core.ProgramResultMatchers._
+import definiti.core.ast.{Library, Root}
+import definiti.core.mock.plugins.StringExtendedContext
+import definiti.core._
+
+class ExtendedContextSpec extends EndToEndSpec {
+  import ExtendedContextSpec._
+
+  "Project.generatePublicAST" should "be valid when extended context is valid on root package" in {
+    val output = processFile("extendedContext.nominal", configuration(ValidExtendedContext))
+    output shouldBe ok[Root]
+  }
+
+  it should "be invalid when extended context is valid on root package" in {
+    val output = processFile("extendedContext.nominal", configuration(InvalidExtendedContext))
+    output should beKo(givenError)
+  }
+
+  it should "be valid when extended context is valid on non-root package" in {
+    val output = processFile("extendedContext.namespace", configuration(ValidExtendedContext))
+    output shouldBe ok[Root]
+  }
+
+  it should "be invalid when extended context is valid on non-root package" in {
+    val output = processFile("extendedContext.namespace", configuration(InvalidExtendedContext))
+    output should beKo(givenError)
+  }
+}
+
+object ExtendedContextSpec {
+
+  val givenError: Alert = AlertSimple("error")
+
+  def configuration(context: StringExtendedContext): ConfigurationMock = {
+    ConfigurationMock(
+      contexts = Seq(context)
+    )
+  }
+
+  object ValidExtendedContext extends StringExtendedContext {
+    override def validate(context: String, library: Library) = Valid(NoResult)
+  }
+
+  object InvalidExtendedContext extends StringExtendedContext {
+    override def validate(context: String, library: Library) = Invalid(Seq(SimpleError(givenError.prettyPrint)))
+  }
+
+}


### PR DESCRIPTION
Currently, validation of extended contexts defined on root namespace
are not triggered.

This commit does the following:

* Include extended contexts of root namespace in validation
* Add test cases for both cases (root and not root)

This commit resolves #56.