### PR TITLE
Uses cats for Program

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ libraryDependencies += "org.antlr" % "antlr4" % "4.7.1"
 libraryDependencies += "com.typesafe" % "config" % "1.3.2"
 libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"
 libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.25"
+libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.1"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.5" % "test"

--- a/src/main/scala/definiti/common/program/Program.scala
+++ b/src/main/scala/definiti/common/program/Program.scala
@@ -1,46 +1,102 @@
 package definiti.common.program
 
+import cats._
 import definiti.common.control.{ControlLevel, ControlResult}
 import definiti.common.program.ProgramResult.NoResult
 import definiti.common.validation._
 
-sealed trait Program[A] {
-  def map[B](op: A => B): Program[B] = MapProgram(this, op)
+import scala.annotation.tailrec
+import scala.util.Either
 
-  def flatMap[B](op: A => Program[B]): Program[B] = FlatMapProgram(this, op)
-
-  def withFilter(predicate: A => Boolean): Program[A] = WithFilterProgram(this, predicate)
-
-  def run(configuration: ProgramConfiguration): ProgramResult[A]
-}
-
-object Program {
-  def apply[A](value: A): Program[A] = new PureProgram[A](value)
-
-  // TODO: Should remove validated to keep only one thing
-  def validated[A](validated: Validated[A]): Program[A] = new ValidatedProgram[A](validated)
-
-  def apply(result: ControlResult): Program[NoResult] = ControlResultProgram(result)
-
-  def apply[A](result: ProgramResult[A]): Program[A] = ResultProgram(result)
-
-  private[program] def runWithControl[A](program: Program[A], configuration: ProgramConfiguration): ProgramResult[A] = {
-    control(program.run(configuration), configuration)
+case class Program[A](private val process: ProgramConfiguration => ProgramResult[A]) {
+  def run(configuration: ProgramConfiguration): ProgramResult[A] = {
+    process(configuration): ProgramResult[A]
   }
 
-  private[program] def control[A](programResult: ProgramResult[A], configuration: ProgramConfiguration): ProgramResult[A] = {
-    programResult match {
-      case Ok(value, alerts) =>
-        if (hasBlockingAlert(alerts, configuration)) {
-          Ko(alerts)
-        } else {
-          Ok(value, alerts)
-        }
+  def withFilter(predicate: A => Boolean): Program[A] = Program { configuration =>
+    process(configuration) match {
+      case Ok(value, alerts) if predicate(value) => Ok(value, alerts)
+      case Ok(_, alerts) => Ko(alerts)
       case Ko(alerts) => Ko(alerts)
     }
   }
+}
 
-  private[program] def hasBlockingAlert(alerts: Seq[Alert], configuration: ProgramConfiguration): Boolean = {
+object Program {
+  def pure[A](value: A): Program[A] = Program(_ => Ok(value))
+
+  def validated[A](validated: Validated[A]): Program[A] = Program { _ =>
+    validated match {
+      case Invalid(errors) => Ko(errors.map(Alert(_)))
+      case Valid(value) => Ok(value)
+    }
+  }
+
+  def control[A](result: ControlResult): Program[NoResult] = Program { implicit configuration =>
+    normalize(Ok(NoResult, result.alerts))
+  }
+
+  implicit val functor: Functor[Program] = new Functor[Program] {
+    override def map[A, B](program: Program[A])(op: A => B): Program[B] = Program { implicit configuration =>
+      normalize(program.process(configuration)) match {
+        case Ok(value, alerts) => Ok(op(value), alerts)
+        case Ko(alerts) => Ko(alerts)
+      }
+    }
+  }
+
+  implicit val applicative: Applicative[Program] = new Applicative[Program] {
+    override def pure[A](value: A): Program[A] = Program.pure(value)
+
+    override def ap[A, B](programF: Program[A => B])(program: Program[A]): Program[B] = Program { implicit configuration =>
+      normalize(program.process(configuration)) match {
+        case Ok(value, alerts) =>
+          normalize(programF.process(configuration)) match {
+            case Ok(aToB, alertsAtoB) => Ok(aToB(value), alerts ++ alertsAtoB)
+            case Ko(alertsAtoB) => Ko(alerts ++ alertsAtoB)
+          }
+        case Ko(alerts) => Ko(alerts)
+      }
+    }
+  }
+
+  implicit val monad: Monad[Program] = new Monad[Program] {
+    override def pure[A](value: A): Program[A] = Program.pure(value)
+
+    override def flatMap[A, B](program: Program[A])(nextProgram: A => Program[B]): Program[B] = Program { implicit configuration =>
+      normalize(program.process(configuration)) match {
+        case Ok(value, alerts) =>
+          normalize(nextProgram(value).process(configuration)) match {
+            case Ok(nextValue, nextAlerts) => Ok(nextValue, alerts ++ nextAlerts)
+            case Ko(nextAlerts) => Ko(alerts ++ nextAlerts)
+          }
+        case Ko(alerts) => Ko(alerts)
+      }
+    }
+
+    override def tailRecM[A, B](initialValue: A)(nextProgram: A => Program[Either[A, B]]): Program[B] = Program { implicit configuration =>
+      @tailrec
+      def process(acc: A, alertsAcc: Seq[Alert]): ProgramResult[B] = {
+        normalize(nextProgram(acc).process(configuration)) match {
+          case Ok(Left(nextValue), alerts) => process(nextValue, alertsAcc ++ alerts)
+          case Ok(Right(finalValue), alerts) => Ok(finalValue, alertsAcc ++ alerts)
+          case Ko(alerts) => Ko(alertsAcc ++ alerts)
+        }
+      }
+
+      process(initialValue, Seq.empty)
+    }
+  }
+
+  private def normalize[A](programResult: ProgramResult[A])(implicit configuration: ProgramConfiguration): ProgramResult[A] = {
+    programResult match {
+      case Ok(_, alerts) if hasBlockingAlert(alerts, configuration) => Ko(alerts)
+      case ok: Ok[A] => ok
+      case ko: Ko[A] => ko
+    }
+  }
+
+  private def hasBlockingAlert(alerts: Seq[Alert], configuration: ProgramConfiguration): Boolean = {
     alerts.exists {
       case AlertControl(control, _, _) =>
         val controlLevel = configuration.userFlags.get(control)
@@ -50,58 +106,4 @@ object Program {
       case _ => false
     }
   }
-}
-
-private[program] case class PureProgram[A](value: A) extends Program[A] {
-  override def run(configuration: ProgramConfiguration): ProgramResult[A] = Ok(value)
-}
-
-private[program] case class MapProgram[A, B](program: Program[A], op: A => B) extends Program[B] {
-  override def run(configuration: ProgramConfiguration): ProgramResult[B] = Program.runWithControl(program, configuration) match {
-    case Ok(value, alerts) => Ok(op(value), alerts)
-    case Ko(alerts) => Ko(alerts)
-  }
-}
-
-private[program] case class FlatMapProgram[A, B](program: Program[A], op: A => Program[B]) extends Program[B] {
-  override def run(configuration: ProgramConfiguration): ProgramResult[B] = Program.runWithControl(program, configuration) match {
-    case Ok(value, alerts) => Program.runWithControl(op(value), configuration) match {
-      case Ok(innerValue, innerAlerts) => Ok(innerValue, alerts ++ innerAlerts)
-      case Ko(innerAlerts) => Ko(alerts ++ innerAlerts)
-    }
-    case Ko(alerts) => Ko(alerts)
-  }
-}
-
-private[program] case class WithFilterProgram[A](program: Program[A], predicate: A => Boolean) extends Program[A] {
-  override def run(configuration: ProgramConfiguration): ProgramResult[A] = Program.runWithControl(program, configuration) match {
-    case Ok(value, alerts) =>
-      if (predicate(value)) {
-        Ok(value, alerts)
-      } else {
-        Ko(alerts)
-      }
-    case Ko(alerts) => Ko(alerts)
-  }
-}
-
-private[program] case class ValidatedProgram[A](validated: Validated[A]) extends Program[A] {
-  override def run(configuration: ProgramConfiguration): ProgramResult[A] = validated match {
-    case Invalid(errors) => Ko(errors.map(Alert(_)))
-    case Valid(value) => Ok(value)
-  }
-}
-
-private[program] case class ControlResultProgram(result: ControlResult) extends Program[NoResult] {
-  override def run(configuration: ProgramConfiguration): ProgramResult[NoResult] = {
-    if (Program.hasBlockingAlert(result.alerts, configuration)) {
-      Ko(result.alerts)
-    } else {
-      Ok(NoResult, result.alerts)
-    }
-  }
-}
-
-private[program] case class ResultProgram[A](result: ProgramResult[A]) extends Program[A] {
-  override def run(configuration: ProgramConfiguration): ProgramResult[A] = Program.control(result, configuration)
 }

--- a/src/main/scala/definiti/core/Project.scala
+++ b/src/main/scala/definiti/core/Project.scala
@@ -3,6 +3,7 @@ package definiti.core
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, StandardOpenOption}
 
+import cats.implicits._
 import definiti.common.ast._
 import definiti.common.program.Program
 import definiti.common.program.ProgramResult.NoResult

--- a/src/main/scala/definiti/core/validation/ASTValidation.scala
+++ b/src/main/scala/definiti/core/validation/ASTValidation.scala
@@ -1,5 +1,6 @@
 package definiti.core.validation
 
+import cats.implicits._
 import definiti.common.ast.{Library, _}
 import definiti.common.plugin.ContextPlugin
 import definiti.common.program.Program

--- a/src/main/scala/definiti/core/validation/Controls.scala
+++ b/src/main/scala/definiti/core/validation/Controls.scala
@@ -7,7 +7,7 @@ import definiti.common.program.{Program, ProgramConfiguration}
 import definiti.core.validation.controls._
 
 class Controls(configuration: ProgramConfiguration) {
-  def validate(root: Root, library: Library): Program[NoResult] = Program {
+  def validate(root: Root, library: Library): Program[NoResult] = Program.control {
     ControlResult.squash {
       Controls.all
         .filter(configuration.isControlAccepted)


### PR DESCRIPTION
To simplify the behavior of `Program` with a more conventional way in scala,
we use cats to describe the `Program` monad.

This commit does the following:

* Import cats
* Transform the Program into cats functor, applicative and monad
* Correct its usage