### PR TITLE
[#78] Restrict naming format

### DIFF
--- a/src/main/scala/definiti/common/tests/LocationPath.scala
+++ b/src/main/scala/definiti/common/tests/LocationPath.scala
@@ -14,11 +14,11 @@ case class LocationPath(path: String) {
 }
 
 object LocationPath {
-  def control(name: String, file: String): LocationPath = {
-    LocationPath(s"src/test/resources/samples/controls/${name}/${file}.def")
+  def control(control: Control[_], file: String): LocationPath = {
+    LocationPath(s"src/test/resources/samples/controls/${control.name}/${file}.def")
   }
 
-  def control(control: Control[_], file: String): LocationPath = {
-    LocationPath.control(control.name, file)
+  def controlNaming(control: Control[_], file: String): LocationPath = {
+    LocationPath(s"src/test/resources/samples/controls/naming/${control.name}/${file}.def")
   }
 }

--- a/src/main/scala/definiti/core/validation/Controls.scala
+++ b/src/main/scala/definiti/core/validation/Controls.scala
@@ -5,6 +5,7 @@ import definiti.common.control.{Control, ControlResult}
 import definiti.common.program.ProgramResult.NoResult
 import definiti.common.program.{Program, ProgramConfiguration}
 import definiti.core.validation.controls._
+import definiti.core.validation.controls.naming._
 
 class Controls(configuration: ProgramConfiguration) {
   def validate(root: Root, library: Library): Program[NoResult] = Program.control {
@@ -18,6 +19,11 @@ class Controls(configuration: ProgramConfiguration) {
 
 object Controls {
   lazy val all: Seq[Control[Root]] = Seq(
+    root,
+    naming
+  ).flatten
+
+  private def root: Seq[Control[Root]] = Seq(
     AliasTypeTypeControl,
     AttributeTypeControl,
     AttributeTypeUniquenessControl,
@@ -45,5 +51,14 @@ object Controls {
     VerificationReferenceControl,
     VerificationReferenceParametersControl,
     VerificationTypeControl
+  )
+
+  private def naming: Seq[Control[Root]] = Seq(
+    NamedFunctionLowerCamelCaseControl,
+    NamedFunctionUpperCamelCaseControl,
+    TypeLowerCamelCaseControl,
+    TypeUpperCamelCaseControl,
+    VerificationLowerCamelCaseControl,
+    VerificationUpperCamelCaseControl
   )
 }

--- a/src/main/scala/definiti/core/validation/controls/naming/NamedFunctionLowerCamelCaseControl.scala
+++ b/src/main/scala/definiti/core/validation/controls/naming/NamedFunctionLowerCamelCaseControl.scala
@@ -1,0 +1,21 @@
+package definiti.core.validation.controls.naming
+
+import definiti.common.ast.{Library, NamedFunction, Root}
+import definiti.common.control.{Control, ControlLevel, ControlResult}
+import definiti.core.validation.helpers.NameFormatHelper
+
+object NamedFunctionLowerCamelCaseControl extends Control[Root] with NameFormatHelper {
+  override def description: String = "Functions must be in lowerCamelCase format"
+
+  override def defaultLevel: ControlLevel.Value = ControlLevel.warning
+
+  override def control(value: Root, library: Library): ControlResult = {
+    ControlResult.squash {
+      library.namedFunctions.map(controlNamedFunction)
+    }
+  }
+
+  private def controlNamedFunction(namedFunction: NamedFunction): ControlResult = {
+    controlLowerCamelCaseFormat(namedFunction.name, namedFunction.location)
+  }
+}

--- a/src/main/scala/definiti/core/validation/controls/naming/NamedFunctionUpperCamelCaseControl.scala
+++ b/src/main/scala/definiti/core/validation/controls/naming/NamedFunctionUpperCamelCaseControl.scala
@@ -1,0 +1,21 @@
+package definiti.core.validation.controls.naming
+
+import definiti.common.ast.{Library, NamedFunction, Root}
+import definiti.common.control.{Control, ControlLevel, ControlResult}
+import definiti.core.validation.helpers.NameFormatHelper
+
+object NamedFunctionUpperCamelCaseControl extends Control[Root] with NameFormatHelper {
+  override def description: String = "Functions must be in UpperCamelCase format"
+
+  override def defaultLevel: ControlLevel.Value = ControlLevel.ignored
+
+  override def control(value: Root, library: Library): ControlResult = {
+    ControlResult.squash {
+      library.namedFunctions.map(controlNamedFunction)
+    }
+  }
+
+  private def controlNamedFunction(namedFunction: NamedFunction): ControlResult = {
+    controlUpperCamelCaseFormat(namedFunction.name, namedFunction.location)
+  }
+}

--- a/src/main/scala/definiti/core/validation/controls/naming/TypeLowerCamelCaseControl.scala
+++ b/src/main/scala/definiti/core/validation/controls/naming/TypeLowerCamelCaseControl.scala
@@ -1,0 +1,34 @@
+package definiti.core.validation.controls.naming
+
+import definiti.common.ast.{DefinedType, Library, ProjectClassDefinition, Root}
+import definiti.common.control.{Control, ControlLevel, ControlResult}
+import definiti.core.validation.helpers.NameFormatHelper
+
+object TypeLowerCamelCaseControl extends Control[Root] with NameFormatHelper {
+  override def description: String = "Type names must be in lowerCamelCase format"
+
+  override def defaultLevel: ControlLevel.Value = ControlLevel.ignored
+
+  override def control(value: Root, library: Library): ControlResult = {
+    ControlResult.squash {
+      library.types
+        .collect {
+          case classDefinition: ProjectClassDefinition => controlType(classDefinition)
+        }
+    }
+  }
+
+  private def controlType(classDefinition: ProjectClassDefinition): ControlResult = {
+    classDefinition match {
+      case definedType: DefinedType =>
+        val nameControl = controlLowerCamelCaseFormat(definedType.name, definedType.location)
+        val attributeTypeControls = definedType.attributes.flatMap { attribute =>
+          attribute.typeName.map(controlLowerCamelCaseFormat(_, attribute.location))
+        }
+        nameControl +: attributeTypeControls
+
+      case other =>
+        controlLowerCamelCaseFormat(other.name, other.location)
+    }
+  }
+}

--- a/src/main/scala/definiti/core/validation/controls/naming/TypeUpperCamelCaseControl.scala
+++ b/src/main/scala/definiti/core/validation/controls/naming/TypeUpperCamelCaseControl.scala
@@ -1,0 +1,34 @@
+package definiti.core.validation.controls.naming
+
+import definiti.common.ast.{DefinedType, Library, ProjectClassDefinition, Root}
+import definiti.common.control.{Control, ControlLevel, ControlResult}
+import definiti.core.validation.helpers.NameFormatHelper
+
+object TypeUpperCamelCaseControl extends Control[Root] with NameFormatHelper {
+  override def description: String = "Type names must be in UpperCamelCase format"
+
+  override def defaultLevel: ControlLevel.Value = ControlLevel.warning
+
+  override def control(value: Root, library: Library): ControlResult = {
+    ControlResult.squash {
+      library.types
+        .collect {
+          case classDefinition: ProjectClassDefinition => controlType(classDefinition)
+        }
+    }
+  }
+
+  private def controlType(classDefinition: ProjectClassDefinition): ControlResult = {
+    classDefinition match {
+      case definedType: DefinedType =>
+        val nameControl = controlUpperCamelCaseFormat(definedType.name, definedType.location)
+        val attributeTypeControls = definedType.attributes.flatMap { attribute =>
+          attribute.typeName.map(controlUpperCamelCaseFormat(_, attribute.location))
+        }
+        nameControl +: attributeTypeControls
+
+      case other =>
+        controlUpperCamelCaseFormat(other.name, other.location)
+    }
+  }
+}

--- a/src/main/scala/definiti/core/validation/controls/naming/VerificationLowerCamelCaseControl.scala
+++ b/src/main/scala/definiti/core/validation/controls/naming/VerificationLowerCamelCaseControl.scala
@@ -1,0 +1,21 @@
+package definiti.core.validation.controls.naming
+
+import definiti.common.ast.{Library, Root, Verification}
+import definiti.common.control.{Control, ControlLevel, ControlResult}
+import definiti.core.validation.helpers.NameFormatHelper
+
+object VerificationLowerCamelCaseControl extends Control[Root] with NameFormatHelper {
+  override def description: String = "Verification names must be in lowerCamelCase format"
+
+  override def defaultLevel: ControlLevel.Value = ControlLevel.ignored
+
+  override def control(value: Root, library: Library): ControlResult = {
+    ControlResult.squash {
+      library.verifications.map(controlVerification)
+    }
+  }
+
+  private def controlVerification(verification: Verification): ControlResult = {
+    controlLowerCamelCaseFormat(verification.name, verification.location)
+  }
+}

--- a/src/main/scala/definiti/core/validation/controls/naming/VerificationUpperCamelCaseControl.scala
+++ b/src/main/scala/definiti/core/validation/controls/naming/VerificationUpperCamelCaseControl.scala
@@ -1,0 +1,21 @@
+package definiti.core.validation.controls.naming
+
+import definiti.common.ast.{Library, Root, Verification}
+import definiti.common.control.{Control, ControlLevel, ControlResult}
+import definiti.core.validation.helpers.NameFormatHelper
+
+object VerificationUpperCamelCaseControl extends Control[Root] with NameFormatHelper {
+  override def description: String = "Verification names must be in UpperCamelCase format"
+
+  override def defaultLevel: ControlLevel.Value = ControlLevel.warning
+
+  override def control(value: Root, library: Library): ControlResult = {
+    ControlResult.squash {
+      library.verifications.map(controlVerification)
+    }
+  }
+
+  private def controlVerification(verification: Verification): ControlResult = {
+    controlUpperCamelCaseFormat(verification.name, verification.location)
+  }
+}

--- a/src/main/scala/definiti/core/validation/helpers/NameFormatHelper.scala
+++ b/src/main/scala/definiti/core/validation/helpers/NameFormatHelper.scala
@@ -1,0 +1,33 @@
+package definiti.core.validation.helpers
+
+import definiti.common.ast.{Location, Root}
+import definiti.common.control.{Control, ControlResult}
+import definiti.common.validation.Alert
+
+private[core] trait NameFormatHelper {
+  self: Control[Root] =>
+
+  def controlUpperCamelCaseFormat(name: String, location: Location): ControlResult = {
+    if (name.headOption.exists(_.isLower)) {
+      invalidUpperCamelCaseFormat(name, location)
+    } else {
+      OK
+    }
+  }
+
+  def invalidUpperCamelCaseFormat(name: String, location: Location): Alert = {
+    alert(s"The name ${name} is not in UpperCamelCase format", location)
+  }
+
+  def controlLowerCamelCaseFormat(name: String, location: Location): ControlResult = {
+    if (name.headOption.exists(_.isUpper)) {
+      invalidLowerCamelCaseFormat(name, location)
+    } else {
+      OK
+    }
+  }
+
+  def invalidLowerCamelCaseFormat(name: String, location: Location): Alert = {
+    alert(s"The name ${name} is not in lowerCamelCase format", location)
+  }
+}

--- a/src/test/resources/samples/controls/naming/namedFunctionLowerCamelCase/invalid.def
+++ b/src/test/resources/samples/controls/naming/namedFunctionLowerCamelCase/invalid.def
@@ -1,0 +1,3 @@
+def MyNamedFunction(): Boolean {
+  true
+}

--- a/src/test/resources/samples/controls/naming/namedFunctionLowerCamelCase/valid.def
+++ b/src/test/resources/samples/controls/naming/namedFunctionLowerCamelCase/valid.def
@@ -1,0 +1,3 @@
+def myNamedFunction(): Boolean {
+  true
+}

--- a/src/test/resources/samples/controls/naming/namedFunctionUpperCamelCase/invalid.def
+++ b/src/test/resources/samples/controls/naming/namedFunctionUpperCamelCase/invalid.def
@@ -1,0 +1,3 @@
+def myNamedFunction(): Boolean {
+  true
+}

--- a/src/test/resources/samples/controls/naming/namedFunctionUpperCamelCase/valid.def
+++ b/src/test/resources/samples/controls/naming/namedFunctionUpperCamelCase/valid.def
@@ -1,0 +1,3 @@
+def MyNamedFunction(): Boolean {
+  true
+}

--- a/src/test/resources/samples/controls/naming/typeLowerCamelCase/invalid.def
+++ b/src/test/resources/samples/controls/naming/typeLowerCamelCase/invalid.def
@@ -1,0 +1,10 @@
+type MyAlias = String
+
+type MyDefined {
+  name: String as MyString
+}
+
+enum MyEnum {
+  One
+  Two
+}

--- a/src/test/resources/samples/controls/naming/typeLowerCamelCase/valid.def
+++ b/src/test/resources/samples/controls/naming/typeLowerCamelCase/valid.def
@@ -1,0 +1,10 @@
+type myAlias = String
+
+type myDefined {
+  name: String as myString
+}
+
+enum myEnum {
+  One
+  Two
+}

--- a/src/test/resources/samples/controls/naming/typeUpperCamelCase/invalid.def
+++ b/src/test/resources/samples/controls/naming/typeUpperCamelCase/invalid.def
@@ -1,0 +1,10 @@
+type myAlias = String
+
+type myDefined {
+  name: String as myString
+}
+
+enum myEnum {
+  One
+  Two
+}

--- a/src/test/resources/samples/controls/naming/typeUpperCamelCase/valid.def
+++ b/src/test/resources/samples/controls/naming/typeUpperCamelCase/valid.def
@@ -1,0 +1,10 @@
+type MyAlias = String
+
+type MyDefined {
+  name: String as MyString
+}
+
+enum MyEnum {
+  One
+  Two
+}

--- a/src/test/resources/samples/controls/naming/verificationLowerCamelCase/invalid.def
+++ b/src/test/resources/samples/controls/naming/verificationLowerCamelCase/invalid.def
@@ -1,0 +1,6 @@
+verification IsNonEmpty {
+  "Should not be empty"
+  (string) {
+    string.nonEmpty()
+  }
+}

--- a/src/test/resources/samples/controls/naming/verificationLowerCamelCase/valid.def
+++ b/src/test/resources/samples/controls/naming/verificationLowerCamelCase/valid.def
@@ -1,0 +1,6 @@
+verification isNonEmpty {
+  "Should not be empty"
+  (string) {
+    string.nonEmpty()
+  }
+}

--- a/src/test/resources/samples/controls/naming/verificationUpperCamelCase/invalid.def
+++ b/src/test/resources/samples/controls/naming/verificationUpperCamelCase/invalid.def
@@ -1,0 +1,6 @@
+verification isNonEmpty {
+  "Should not be empty"
+  (string) {
+    string.nonEmpty()
+  }
+}

--- a/src/test/resources/samples/controls/naming/verificationUpperCamelCase/valid.def
+++ b/src/test/resources/samples/controls/naming/verificationUpperCamelCase/valid.def
@@ -1,0 +1,6 @@
+verification IsNonEmpty {
+  "Should not be empty"
+  (string) {
+    string.nonEmpty()
+  }
+}

--- a/src/test/scala/definiti/core/end2end/controls/naming/NamedFunctionLowerCamelCaseControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/naming/NamedFunctionLowerCamelCaseControlSpec.scala
@@ -1,0 +1,32 @@
+package definiti.core.end2end.controls.naming
+
+import definiti.common.ast.Root
+import definiti.common.program.Ko
+import definiti.common.tests.{ConfigurationMock, LocationPath}
+import definiti.core.ProgramResultMatchers.{ok, _}
+import definiti.core.end2end.EndToEndSpec
+import definiti.core.validation.controls.naming.NamedFunctionLowerCamelCaseControl
+
+class NamedFunctionLowerCamelCaseControlSpec extends EndToEndSpec {
+
+  import NamedFunctionLowerCamelCaseControlSpec._
+
+  "Project.generatePublicAST" should "validate a named function with a valid lowerCamelCame format" in {
+    val output = processFile("controls.naming.namedFunctionLowerCamelCase.valid", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "invalidate a named function with an invalid lowerCamelCame format" in {
+    val output = processFile("controls.naming.namedFunctionLowerCamelCase.invalid", configuration)
+    output should beResult(Ko[Root](
+      NamedFunctionLowerCamelCaseControl.invalidLowerCamelCaseFormat("MyNamedFunction", invalidLocation(1, 1, 3, 2))
+    ))
+  }
+
+}
+
+object NamedFunctionLowerCamelCaseControlSpec {
+  val configuration = ConfigurationMock().withOnlyControls(NamedFunctionLowerCamelCaseControl)
+
+  val invalidLocation = LocationPath.controlNaming(NamedFunctionLowerCamelCaseControl, "invalid")
+}

--- a/src/test/scala/definiti/core/end2end/controls/naming/NamedFunctionUpperCamelCaseControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/naming/NamedFunctionUpperCamelCaseControlSpec.scala
@@ -1,0 +1,31 @@
+package definiti.core.end2end.controls.naming
+
+import definiti.common.ast.Root
+import definiti.common.program.Ko
+import definiti.common.tests.{ConfigurationMock, LocationPath}
+import definiti.core.ProgramResultMatchers.{beResult, ok}
+import definiti.core.end2end.EndToEndSpec
+import definiti.core.validation.controls.naming.NamedFunctionUpperCamelCaseControl
+
+class NamedFunctionUpperCamelCaseControlSpec extends EndToEndSpec {
+
+  import NamedFunctionUpperCamelCaseControlSpec._
+
+  "Project.generatePublicAST" should "validate a named function with a valid upperCamelCame format" in {
+    val output = processFile("controls.naming.namedFunctionUpperCamelCase.valid", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "invalidate a named function with an invalid UpperCamelCame format" in {
+    val output = processFile("controls.naming.namedFunctionUpperCamelCase.invalid", configuration)
+    output should beResult(Ko[Root](
+      NamedFunctionUpperCamelCaseControl.invalidUpperCamelCaseFormat("myNamedFunction", invalidLocation(1, 1, 3, 2))
+    ))
+  }
+}
+
+object NamedFunctionUpperCamelCaseControlSpec {
+  val configuration = ConfigurationMock().withOnlyControls(NamedFunctionUpperCamelCaseControl)
+
+  val invalidLocation = LocationPath.controlNaming(NamedFunctionUpperCamelCaseControl, "invalid")
+}

--- a/src/test/scala/definiti/core/end2end/controls/naming/TypeLowerCamelCaseControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/naming/TypeLowerCamelCaseControlSpec.scala
@@ -1,0 +1,34 @@
+package definiti.core.end2end.controls.naming
+
+import definiti.common.ast.Root
+import definiti.common.program.Ko
+import definiti.common.tests.{ConfigurationMock, LocationPath}
+import definiti.core.ProgramResultMatchers.{beResult, ok}
+import definiti.core.end2end.EndToEndSpec
+import definiti.core.validation.controls.naming.TypeLowerCamelCaseControl
+
+class TypeLowerCamelCaseControlSpec extends EndToEndSpec {
+
+  import TypeLowerCamelCaseControlSpec._
+
+  "Project.generatePublicAST" should "validate a type with a valid lowerCamelCame format" in {
+    val output = processFile("controls.naming.typeLowerCamelCase.valid", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "invalidate a type with an invalid lowerCamelCame format" in {
+    val output = processFile("controls.naming.typeLowerCamelCase.invalid", configuration)
+    output should beResult(Ko[Root](
+      TypeLowerCamelCaseControl.invalidLowerCamelCaseFormat("MyAlias", invalidLocation(1, 1, 22)),
+      TypeLowerCamelCaseControl.invalidLowerCamelCaseFormat("MyDefined", invalidLocation(3, 1, 5, 2)),
+      TypeLowerCamelCaseControl.invalidLowerCamelCaseFormat("MyString", invalidLocation(4, 3, 27)),
+      TypeLowerCamelCaseControl.invalidLowerCamelCaseFormat("MyEnum", invalidLocation(7, 1, 10, 2))
+    ))
+  }
+}
+
+object TypeLowerCamelCaseControlSpec {
+  val configuration = ConfigurationMock().withOnlyControls(TypeLowerCamelCaseControl)
+
+  val invalidLocation = LocationPath.controlNaming(TypeLowerCamelCaseControl, "invalid")
+}

--- a/src/test/scala/definiti/core/end2end/controls/naming/TypeUpperCamelCaseControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/naming/TypeUpperCamelCaseControlSpec.scala
@@ -1,0 +1,34 @@
+package definiti.core.end2end.controls.naming
+
+import definiti.common.ast.Root
+import definiti.common.program.Ko
+import definiti.common.tests.{ConfigurationMock, LocationPath}
+import definiti.core.ProgramResultMatchers.{beResult, ok}
+import definiti.core.end2end.EndToEndSpec
+import definiti.core.validation.controls.naming.TypeUpperCamelCaseControl
+
+class TypeUpperCamelCaseControlSpec extends EndToEndSpec {
+
+  import TypeUpperCamelCaseControlSpec._
+
+  "Project.generatePublicAST" should "validate a type with a valid UpperCamelCame format" in {
+    val output = processFile("controls.naming.typeUpperCamelCase.valid", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "invalidate a type with an invalid UpperCamelCame format" in {
+    val output = processFile("controls.naming.typeUpperCamelCase.invalid", configuration)
+    output should beResult(Ko[Root](
+      TypeUpperCamelCaseControl.invalidUpperCamelCaseFormat("myAlias", invalidLocation(1, 1, 22)),
+      TypeUpperCamelCaseControl.invalidUpperCamelCaseFormat("myDefined", invalidLocation(3, 1, 5, 2)),
+      TypeUpperCamelCaseControl.invalidUpperCamelCaseFormat("myString", invalidLocation(4, 3, 27)),
+      TypeUpperCamelCaseControl.invalidUpperCamelCaseFormat("myEnum", invalidLocation(7, 1, 10, 2))
+    ))
+  }
+}
+
+object TypeUpperCamelCaseControlSpec {
+  val configuration = ConfigurationMock().withOnlyControls(TypeUpperCamelCaseControl)
+
+  val invalidLocation = LocationPath.controlNaming(TypeUpperCamelCaseControl, "invalid")
+}

--- a/src/test/scala/definiti/core/end2end/controls/naming/VerificationLowerCamelCaseControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/naming/VerificationLowerCamelCaseControlSpec.scala
@@ -1,0 +1,31 @@
+package definiti.core.end2end.controls.naming
+
+import definiti.common.ast.Root
+import definiti.common.program.Ko
+import definiti.common.tests.{ConfigurationMock, LocationPath}
+import definiti.core.ProgramResultMatchers.{beResult, ok}
+import definiti.core.end2end.EndToEndSpec
+import definiti.core.validation.controls.naming.VerificationLowerCamelCaseControl
+
+class VerificationLowerCamelCaseControlSpec extends EndToEndSpec {
+
+  import VerificationLowerCamelCaseControlSpec._
+
+  "Project.generatePublicAST" should "validate a verification with a valid lowerCamelCame format" in {
+    val output = processFile("controls.naming.verificationLowerCamelCase.valid", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "invalidate a verification with an invalid lowerCamelCame format" in {
+    val output = processFile("controls.naming.verificationLowerCamelCase.invalid", configuration)
+    output should beResult(Ko[Root](
+      VerificationLowerCamelCaseControl.invalidLowerCamelCaseFormat("IsNonEmpty", invalidLocation(1, 1, 6, 2))
+    ))
+  }
+}
+
+object VerificationLowerCamelCaseControlSpec {
+  val configuration = ConfigurationMock().withOnlyControls(VerificationLowerCamelCaseControl)
+
+  val invalidLocation = LocationPath.controlNaming(VerificationLowerCamelCaseControl, "invalid")
+}

--- a/src/test/scala/definiti/core/end2end/controls/naming/VerificationUpperCamelCaseControlSpec.scala
+++ b/src/test/scala/definiti/core/end2end/controls/naming/VerificationUpperCamelCaseControlSpec.scala
@@ -1,0 +1,31 @@
+package definiti.core.end2end.controls.naming
+
+import definiti.common.ast.Root
+import definiti.common.program.Ko
+import definiti.common.tests.{ConfigurationMock, LocationPath}
+import definiti.core.ProgramResultMatchers.{beResult, ok}
+import definiti.core.end2end.EndToEndSpec
+import definiti.core.validation.controls.naming.VerificationUpperCamelCaseControl
+
+class VerificationUpperCamelCaseControlSpec extends EndToEndSpec {
+
+  import VerificationUpperCamelCaseControlSpec._
+
+  "Project.generatePublicAST" should "validate a verification with a valid UpperCamelCame format" in {
+    val output = processFile("controls.naming.verificationUpperCamelCase.valid", configuration)
+    output shouldBe ok[Root]
+  }
+
+  it should "invalidate a verification with an invalid UpperCamelCame format" in {
+    val output = processFile("controls.naming.verificationUpperCamelCase.invalid", configuration)
+    output should beResult(Ko[Root](
+      VerificationUpperCamelCaseControl.invalidUpperCamelCaseFormat("isNonEmpty", invalidLocation(1, 1, 6, 2))
+    ))
+  }
+}
+
+object VerificationUpperCamelCaseControlSpec {
+  val configuration = ConfigurationMock().withOnlyControls(VerificationUpperCamelCaseControl)
+
+  val invalidLocation = LocationPath.controlNaming(VerificationUpperCamelCaseControl, "invalid")
+}


### PR DESCRIPTION
To add quality control on the code, add restriction in naming.
These restriction are not blocking by default (level warning or ignored)

This commit does the following:

- Add controls for naming:
  - Named functions
  - Types (defined type, alias type, enum, attribute type)
  - Verifications
  - But them in their own package because they are similar and the main package becomes too big
- Add tests verifying new controls

This PR resolves #78.